### PR TITLE
Add video pipeline scripts and agent

### DIFF
--- a/app/client/agent/video_summarizer_agent.py
+++ b/app/client/agent/video_summarizer_agent.py
@@ -1,0 +1,23 @@
+from pathlib import Path
+from pydantic import BaseModel
+from agents import Agent
+
+class VideoSummaryOutput(BaseModel):
+    summary: str
+    teaching_points: list[str]
+    visual_prompt: str
+    hockey_skills: list[str]
+    position: list[str] | None = []
+    complexity: str | None = None
+
+
+def _load_prompt() -> str:
+    path = Path(__file__).resolve().parent.parent.parent.parent / "prompts" / "video_summarizer_prompt.yaml"
+    with open(path, "r", encoding="utf-8") as f:
+        return "".join(f.readlines()[1:]).lstrip()
+
+video_summarizer_agent = Agent(
+    name="VideoSummarizerAgent",
+    instructions=_load_prompt(),
+    output_type=VideoSummaryOutput,
+)

--- a/data/processed/video_clips.json
+++ b/data/processed/video_clips.json
@@ -1,0 +1,13 @@
+[
+  {
+    "title": "Sample Hockey Clip",
+    "video_url": "https://www.youtube.com/watch?v=example",
+    "source": "SampleChannel",
+    "summary": "How to improve your wrist shot with proper weight transfer.",
+    "teaching_points": ["Knees bent", "Transfer weight from back foot"],
+    "visual_prompt": "Player demonstrating wrist shot with bent knees",
+    "hockey_skills": ["Shooting"],
+    "position": ["Forward"],
+    "complexity": "Beginner"
+  }
+]

--- a/prompts/video_summarizer_prompt.yaml
+++ b/prompts/video_summarizer_prompt.yaml
@@ -1,0 +1,8 @@
+prompt: |
+  You are a hockey coaching assistant helping to distill key knowledge from tutorial videos.
+
+  Given a transcript segment from a hockey instruction video, produce a short summary of the key coaching advice.
+  List bullet point teaching points, tag the relevant hockey skills and positions if mentioned, and provide a short visual description that could accompany the clip.
+  Optionally assign a complexity level (Beginner, Intermediate, Advanced) if obvious from context.
+
+  Respond in JSON matching the VideoSummaryOutput model.

--- a/scripts/index_video_clips_chroma.py
+++ b/scripts/index_video_clips_chroma.py
@@ -1,0 +1,54 @@
+# scripts/index_video_clips_chroma.py
+import json
+from pathlib import Path
+
+import sys
+sys.path.append(str(Path(__file__).resolve().parent.parent))
+from app.mcp_server.chroma_utils import get_chroma_collection, clear_chroma_collection
+
+DATA_PATH = Path(__file__).parent.parent / "data" / "processed" / "video_clips.json"
+
+clear_chroma_collection()
+collection = get_chroma_collection()
+
+with open(DATA_PATH, "r", encoding="utf-8") as f:
+    data = json.load(f)
+
+
+def clip_text(clip: dict) -> str:
+    parts = [
+        f"Title: {clip.get('title', '')}",
+        f"Summary: {clip.get('summary', '')}",
+        "Teaching Points: " + ", ".join(clip.get("teaching_points", [])),
+        "Skills: " + ", ".join(clip.get("hockey_skills", [])),
+        "Positions: " + ", ".join(clip.get("position", [])),
+        f"Complexity: {clip.get('complexity', '')}",
+    ]
+    return "\n".join(part for part in parts if part)
+
+
+def metadata_for(clip: dict) -> dict:
+    return {
+        "title": clip.get("title", ""),
+        "summary": clip.get("summary", ""),
+        "teaching_points": "; ".join(clip.get("teaching_points", [])),
+        "hockey_skills": "; ".join(clip.get("hockey_skills", [])),
+        "position": "; ".join(clip.get("position", [])),
+        "complexity": clip.get("complexity", ""),
+        "source": clip.get("source", ""),
+        "video_url": clip.get("video_url", ""),
+    }
+
+
+docs = [clip_text(c) for c in data]
+metadatas = [metadata_for(c) for c in data]
+ids = [f"video-{i}" for i in range(len(data))]
+collection.add(documents=docs, metadatas=metadatas, ids=ids)
+print("Count:", collection.count())
+results = collection.get(include=["documents", "metadatas"], limit=5)
+for i, doc in enumerate(results["documents"]):
+    print(f"Doc {i+1}:")
+    print("  ID:", results["ids"][i])
+    print("  Title:", results["metadatas"][i].get("title"))
+    print("  Text:", doc[:100], "...")
+print(f"✅ Indexed {len(docs)} video clips into Chroma")

--- a/scripts/process_video_transcripts.py
+++ b/scripts/process_video_transcripts.py
@@ -1,0 +1,120 @@
+#!/usr/bin/env python3
+"""Download YouTube video audio, transcribe with Whisper, summarize segments."""
+import argparse
+import asyncio
+import json
+import os
+from pathlib import Path
+from typing import List
+import sys
+
+# Add repo root to PYTHONPATH so `app` package can be imported
+sys.path.append(str(Path(__file__).resolve().parent.parent))
+
+import yt_dlp
+import whisper
+
+from agents import Runner
+from app.client.agent.video_summarizer_agent import video_summarizer_agent, VideoSummaryOutput
+
+
+# --- Helpers ---
+def download_audio(url: str, out_dir: Path) -> tuple[Path, dict]:
+    """Download audio using yt-dlp and return file path and video info."""
+    out_dir.mkdir(parents=True, exist_ok=True)
+    ydl_opts = {
+        "format": "bestaudio/best",
+        "outtmpl": str(out_dir / "%(id)s.%(ext)s"),
+        "quiet": True,
+    }
+    with yt_dlp.YoutubeDL(ydl_opts) as ydl:
+        info = ydl.extract_info(url, download=True)
+        filename = Path(ydl.prepare_filename(info)).with_suffix(".mp3")
+    return filename, info
+
+
+def transcribe_audio(audio_path: Path) -> dict:
+    model = whisper.load_model("base")
+    return model.transcribe(str(audio_path))
+
+
+def group_segments(segments: List[dict], max_words: int = 80) -> List[str]:
+    chunks: List[str] = []
+    current: List[str] = []
+    word_count = 0
+    for seg in segments:
+        words = seg["text"].split()
+        if word_count + len(words) > max_words and current:
+            chunks.append(" ".join(current))
+            current = words
+            word_count = len(words)
+        else:
+            current += words
+            word_count += len(words)
+    if current:
+        chunks.append(" ".join(current))
+    return chunks
+
+
+async def summarize_chunks(chunks: List[str], title: str) -> List[VideoSummaryOutput]:
+    results = []
+    for i, chunk in enumerate(chunks):
+        print(f"\n📝 Summarizing segment {i+1}/{len(chunks)} ({len(chunk.split())} words)...")
+        agent_input = f"Video Title: {title}\nTranscript Segment:\n{chunk}"
+        try:
+            run = await Runner.run(video_summarizer_agent, agent_input)
+            summary = run.final_output_as(VideoSummaryOutput)
+        except Exception as e:
+            print(f"❌ Agent call failed: {e}")
+            continue
+        print(f"✅ Segment {i+1} summarized")
+        print(summary.model_dump_json(indent=2))
+        results.append(summary)
+    return results
+
+
+async def process_video(url: str, out_json: Path) -> None:
+    tmp_dir = Path("tmp_video")
+    audio_path, info = download_audio(url, tmp_dir)
+    print(f"📥 Downloaded {audio_path}")
+    transcript = transcribe_audio(audio_path)
+    print("📜 Transcription complete")
+    chunks = group_segments(transcript.get("segments", []))
+    summaries = await summarize_chunks(chunks, info.get("title", ""))
+
+    clips = []
+    for s in summaries:
+        clip = {
+            "title": info.get("title"),
+            "video_url": url,
+            "source": info.get("uploader"),
+            "summary": s.summary,
+            "teaching_points": s.teaching_points,
+            "visual_prompt": s.visual_prompt,
+            "hockey_skills": s.hockey_skills,
+            "position": s.position,
+            "complexity": s.complexity,
+        }
+        clips.append(clip)
+
+    existing = []
+    if out_json.exists():
+        with open(out_json, "r", encoding="utf-8") as f:
+            existing = json.load(f)
+    existing.extend(clips)
+    with open(out_json, "w", encoding="utf-8") as f:
+        json.dump(existing, f, indent=2)
+    print(f"✅ Wrote {len(clips)} clips to {out_json}")
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Process YouTube videos into transcripts and summaries")
+    parser.add_argument("--url", action="append", required=True, help="YouTube video URL")
+    parser.add_argument("--output", type=Path, default=Path("data/processed/video_clips.json"))
+    args = parser.parse_args()
+
+    asyncio.run(process_video(args.url[0], args.output))
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add `video_summarizer_agent` for extracting key points from video transcripts
- new prompt for video summarization
- script to download YouTube videos, transcribe with Whisper, and create `video_clips.json`
- script to index `video_clips.json` into Chroma
- provide initial sample `video_clips.json`

## Testing
- `python scripts/process_video_transcripts.py --url https://www.youtube.com/watch?v=dQw4w9WgXcQ --output data/processed/video_clips.json` *(fails: unable to download video due to proxy restrictions)*
- `python scripts/index_video_clips_chroma.py` *(fails: CHROMA_OPENAI_API_KEY not set)*

------
https://chatgpt.com/codex/tasks/task_e_68668a964838832699f863785f01d6d2