### PR TITLE
Add timestamps and metadata to video processing

### DIFF
--- a/app/client/agent/video_summarizer_agent.py
+++ b/app/client/agent/video_summarizer_agent.py
@@ -9,6 +9,9 @@ class VideoSummaryOutput(BaseModel):
     hockey_skills: list[str]
     position: list[str] | None = []
     complexity: str | None = None
+    clip_type: str | None = None
+    intended_audience: str | None = None
+    play_or_skill_focus: str | None = None
 
 
 def _load_prompt() -> str:

--- a/prompts/video_summarizer_prompt.yaml
+++ b/prompts/video_summarizer_prompt.yaml
@@ -4,5 +4,9 @@ prompt: |
   Given a transcript segment from a hockey instruction video, produce a short summary of the key coaching advice.
   List bullet point teaching points, tag the relevant hockey skills and positions if mentioned, and provide a short visual description that could accompany the clip.
   Optionally assign a complexity level (Beginner, Intermediate, Advanced) if obvious from context.
+  If clear from the transcript, you may also provide optional fields:
+    - `clip_type` (e.g. "Drill Explanation", "Demonstration")
+    - `intended_audience` (e.g. "U9 Player", "Beginner Coach")
+    - `play_or_skill_focus` (e.g. "Puck Protection")
 
   Respond in JSON matching the VideoSummaryOutput model.

--- a/scripts/process_video_transcripts.py
+++ b/scripts/process_video_transcripts.py
@@ -5,7 +5,8 @@ import asyncio
 import json
 import os
 from pathlib import Path
-from typing import List
+from typing import List, Dict
+import csv
 import sys
 
 # Add repo root to PYTHONPATH so `app` package can be imported
@@ -38,29 +39,38 @@ def transcribe_audio(audio_path: Path) -> dict:
     return model.transcribe(str(audio_path))
 
 
-def group_segments(segments: List[dict], max_words: int = 80) -> List[str]:
-    chunks: List[str] = []
-    current: List[str] = []
+def group_segments(segments: List[dict], max_words: int = 80) -> List[Dict[str, float | str]]:
+    """Group whisper segments into larger text chunks while preserving timestamps."""
+    chunks: List[Dict[str, float | str]] = []
+    current_words: List[str] = []
+    start_time: float | None = None
+    end_time: float | None = None
     word_count = 0
     for seg in segments:
         words = seg["text"].split()
-        if word_count + len(words) > max_words and current:
-            chunks.append(" ".join(current))
-            current = words
+        if start_time is None:
+            start_time = float(seg.get("start", 0))
+        if word_count + len(words) > max_words and current_words:
+            chunks.append({"text": " ".join(current_words), "start": start_time, "end": end_time or start_time})
+            current_words = words
+            start_time = float(seg.get("start", 0))
+            end_time = float(seg.get("end", 0))
             word_count = len(words)
         else:
-            current += words
+            current_words += words
+            end_time = float(seg.get("end", 0))
             word_count += len(words)
-    if current:
-        chunks.append(" ".join(current))
+    if current_words:
+        chunks.append({"text": " ".join(current_words), "start": start_time or 0.0, "end": end_time or (start_time or 0.0)})
     return chunks
 
 
-async def summarize_chunks(chunks: List[str], title: str) -> List[VideoSummaryOutput]:
+async def summarize_chunks(chunks: List[Dict[str, float | str]], title: str) -> List[VideoSummaryOutput]:
     results = []
     for i, chunk in enumerate(chunks):
-        print(f"\n📝 Summarizing segment {i+1}/{len(chunks)} ({len(chunk.split())} words)...")
-        agent_input = f"Video Title: {title}\nTranscript Segment:\n{chunk}"
+        text = chunk["text"]
+        print(f"\n📝 Summarizing segment {i+1}/{len(chunks)} ({len(text.split())} words)...")
+        agent_input = f"Video Title: {title}\nTranscript Segment:\n{text}"
         try:
             run = await Runner.run(video_summarizer_agent, agent_input)
             summary = run.final_output_as(VideoSummaryOutput)
@@ -83,17 +93,26 @@ async def process_video(url: str, out_json: Path) -> None:
     summaries = await summarize_chunks(chunks, info.get("title", ""))
 
     clips = []
-    for s in summaries:
+    for idx, (s, chunk) in enumerate(zip(summaries, chunks)):
+        start_time = float(chunk.get("start", 0))
+        end_time = float(chunk.get("end", start_time))
         clip = {
+            "segment_number": idx + 1,
             "title": info.get("title"),
-            "video_url": url,
+            "video_url": f"{url}?t={int(start_time)}",
             "source": info.get("uploader"),
+            "start_time": start_time,
+            "end_time": end_time,
             "summary": s.summary,
             "teaching_points": s.teaching_points,
             "visual_prompt": s.visual_prompt,
             "hockey_skills": s.hockey_skills,
             "position": s.position,
             "complexity": s.complexity,
+            "clip_type": s.clip_type,
+            "intended_audience": s.intended_audience,
+            "play_or_skill_focus": s.play_or_skill_focus,
+            "duration": round(end_time - start_time, 2),
         }
         clips.append(clip)
 
@@ -105,6 +124,21 @@ async def process_video(url: str, out_json: Path) -> None:
     with open(out_json, "w", encoding="utf-8") as f:
         json.dump(existing, f, indent=2)
     print(f"✅ Wrote {len(clips)} clips to {out_json}")
+
+    # Bonus: also export CSV for spreadsheet users
+    csv_path = out_json.with_suffix(".csv")
+    fieldnames = list(clips[0].keys()) if clips else []
+    if fieldnames:
+        if csv_path.exists():
+            with open(csv_path, "r", encoding="utf-8") as f:
+                pass  # ensure file exists for append
+        write_header = not csv_path.exists()
+        with open(csv_path, "a", newline="", encoding="utf-8") as f:
+            writer = csv.DictWriter(f, fieldnames=fieldnames)
+            if write_header:
+                writer.writeheader()
+            writer.writerows(clips)
+        print(f"✅ Appended clips to {csv_path}")
 
 
 def main() -> None:


### PR DESCRIPTION
## Summary
- extend `VideoSummaryOutput` with optional metadata fields
- allow summarization prompt to provide extra context fields
- update transcript processing to keep start/end times
- include segment number, timestamp links and optional duration
- export processed clips to CSV for convenience

## Testing
- `python -m py_compile scripts/process_video_transcripts.py app/client/agent/video_summarizer_agent.py`
- `python scripts/process_video_transcripts.py --url https://youtu.be/l9cN8j6au2U --output data/processed/video_clips.json` *(fails: yt-dlp cannot access YouTube)*

------
https://chatgpt.com/codex/tasks/task_e_6866d462d2508326ba35e83cd54ef640