### PR TITLE
Add segment/video IDs to clip processing

### DIFF
--- a/scripts/index_video_clips_chroma.py
+++ b/scripts/index_video_clips_chroma.py
@@ -44,6 +44,7 @@ def metadata_for(clip: dict) -> dict:
     """Flatten clip fields for easier filtering/search."""
     return {
         "segment_number": str(clip.get("segment_number", "")),
+        "segment_id": clip.get("segment_id", ""),
         "title": clip.get("title", ""),
         "summary": clip.get("summary", ""),
         "teaching_points": "; ".join(clip.get("teaching_points", [])),
@@ -98,9 +99,9 @@ def main() -> None:
     for clip in data:
         docs.append(clip_text(clip))
         metadatas.append(metadata_for(clip))
-        vid_id = extract_video_id(clip.get("video_url", ""))
-        seg_num = clip.get("segment_number", "")
-        ids.append(f"video-{vid_id}-{seg_num}")
+        vid_id = clip.get("video_id") or extract_video_id(clip.get("video_url", ""))
+        seg_id = clip.get("segment_id") or f"{vid_id}_{clip.get('segment_number', '')}"
+        ids.append(f"video-{seg_id}")
 
     if docs:
         collection.add(documents=docs, metadatas=metadatas, ids=ids)


### PR DESCRIPTION
## Summary
- add stable `video_id` and `segment_id` when extracting clips
- normalize `position` field
- skip duplicates based on `video_id` with optional `--force`
- index `segment_id` when adding clips to Chroma

## Testing
- `python scripts/process_video_transcripts.py --url-file data/input/channel_videos.txt --output data/processed/video_clips.json` *(fails: Tunnel connection failed: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68681d98231883269ad34cfc8119bcfa