### PR TITLE
Fix LTAD json parsing

### DIFF
--- a/prompts/ltad_stage1_parse_skills.yaml
+++ b/prompts/ltad_stage1_parse_skills.yaml
@@ -1,6 +1,20 @@
 prompt: |
-  You parse a raw text section that lists hockey skills or drills.
-  For each bullet point or table row, return a JSON object with:
-    skill_name, skill_category, raw_description.
-  Infer the skill category when possible.
-  Respond only with a JSON list.
+  You are an expert hockey development coach. Given a raw skill section, parse it into structured skill items.
+
+  Return each skill as an object with:
+  - skill_name (e.g., "Backward C-cuts")
+  - skill_category (e.g., "Skating", "Passing")
+  - raw_description (short explanation if needed)
+
+  Use this JSON format:
+  ```json
+  [
+    {
+      "skill_name": "Backward C-cuts",
+      "skill_category": "Skating",
+      "raw_description": "Focus on wide stance and edge control"
+    }
+  ]
+  ```
+
+  Return only the JSON block.

--- a/prompts/ltad_stage2_enrich_skills.yaml
+++ b/prompts/ltad_stage2_enrich_skills.yaml
@@ -2,4 +2,18 @@ prompt: |
   You convert a raw skill row into a structured LTADSkill object for youth hockey development.
   Fill the fields when possible: age_group, ltad_stage, position, skill_category, skill_name, teaching_notes, season_month, source.
   Use null if information is missing. Provide concise teaching_notes.
-  Respond only with a JSON object.
+  Return a single JSON object like:
+  ```json
+  {
+    "age_group": "U9",
+    "ltad_stage": "Fundamentals 2",
+    "position": ["Any"],
+    "skill_category": "Skating",
+    "skill_name": "T-push",
+    "teaching_notes": "Used for lateral movement. Emphasize quick recovery and balance.",
+    "season_month": null,
+    "source": "u9-core-skills-e.pdf"
+  }
+  ```
+
+  Return only the JSON block.

--- a/scripts/extract_ltad_skills.py
+++ b/scripts/extract_ltad_skills.py
@@ -40,9 +40,14 @@ PROMPT_STAGE2 = load_prompt(PROMPT_DIR / "ltad_stage2_enrich_skills.yaml")
 def _parse_json(content: str) -> list[dict] | dict | None:
     """Safely parse JSON content from an LLM response."""
     try:
+        if content.startswith("```json"):
+            content = (
+                content.strip().split("```json", 1)[1].split("```", 1)[0].strip()
+            )
         return json.loads(content)
     except Exception as e:
         print(f"❌ JSON parse failed: {e}")
+        print("🔍 Raw content was:\n", content)
         return None
 
 


### PR DESCRIPTION
## Summary
- sanitize json output from the LLM to support markdown wrapped replies
- improve stage1 and stage2 prompts with detailed JSON examples

## Testing
- `uv run scripts/extract_ltad_skills.py --input-folder data/raw/ltad --output data/processed/ltad_skills_raw.json` *(fails: OpenAI API key not provided)*

------
https://chatgpt.com/codex/tasks/task_e_686d2ad0773c83268159e2e70d3d79de