### PR TITLE
Enhance LTAD pipeline with LLM-based normalization

### DIFF
--- a/ltad_normalizer.py
+++ b/ltad_normalizer.py
@@ -1,0 +1,63 @@
+"""Utility to normalize and infer LTAD skill metadata using an LLM."""
+
+from __future__ import annotations
+import json
+import re
+from pathlib import Path
+
+import yaml
+from openai import OpenAI
+from models.ltad import LTADSkill
+
+client = OpenAI()
+
+PROMPT_PATH = Path(__file__).resolve().parent / "prompts" / "ltad_stage3_normalize.yaml"
+with open(PROMPT_PATH, "r", encoding="utf-8") as f:
+    PROMPT = yaml.safe_load(f).get("prompt", "")
+
+LTAD_STAGE_LOOKUP = {
+    "U7": "Fundamentals 1",
+    "U9": "Fundamentals 2",
+    "U11": "Learn to Train",
+    "U13": "Train to Train",
+}
+
+def infer_age_group_from_filename(filename: str) -> str | None:
+    match = re.search(r"u\d{1,2}", filename.lower())
+    if match:
+        return match.group(0).upper()
+    return None
+
+
+def _parse_json(content: str) -> dict | None:
+    try:
+        if content.startswith("```json"):
+            content = content.split("```json", 1)[1].split("```", 1)[0]
+        return json.loads(content)
+    except Exception:
+        return None
+
+def normalize_ltad_skill(skill: dict) -> dict:
+    """Use the LLM to canonicalize skill name/variant and infer metadata."""
+    # Pre-fill missing fields using heuristics
+    if not skill.get("age_group") and skill.get("source"):
+        inferred = infer_age_group_from_filename(skill["source"])
+        if inferred:
+            skill["age_group"] = inferred
+
+    if not skill.get("ltad_stage") and skill.get("age_group"):
+        skill["ltad_stage"] = LTAD_STAGE_LOOKUP.get(skill["age_group"], "Not provided")
+
+    user = json.dumps(skill, indent=2)
+    resp = client.chat.completions.create(
+        model="gpt-3.5-turbo-0125",
+        temperature=0,
+        messages=[{"role": "system", "content": PROMPT}, {"role": "user", "content": user}],
+    )
+    data = _parse_json(resp.choices[0].message.content)
+    if isinstance(data, dict):
+        try:
+            return LTADSkill(**data).model_dump()
+        except Exception:
+            pass
+    return skill

--- a/models/ltad.py
+++ b/models/ltad.py
@@ -10,4 +10,7 @@ class LTADSkill(BaseModel):
     skill_name: str | None = None
     teaching_notes: str | None = None
     season_month: str | None = None
+    progression_stage: str | None = None  # Introductory, Developmental, Refinement
+    teaching_complexity: int | None = None  # 1 = beginner, 2 = intermediate, 3 = advanced
+    variant: str | None = None
     source: str

--- a/prompts/ltad_stage2_enrich_skills.yaml
+++ b/prompts/ltad_stage2_enrich_skills.yaml
@@ -1,6 +1,6 @@
 prompt: |
   You convert a raw skill row into a structured LTADSkill object for youth hockey development.
-  Fill the fields when possible: age_group, ltad_stage, position, skill_category, skill_name, teaching_notes, season_month, source.
+  Fill the fields when possible: age_group, ltad_stage, position, skill_category, skill_name, teaching_notes, season_month, progression_stage, teaching_complexity, variant, source.
   Use null if information is missing. Provide concise teaching_notes.
   Return a single JSON object like:
   ```json
@@ -12,8 +12,14 @@ prompt: |
     "skill_name": "T-push",
     "teaching_notes": "Used for lateral movement. Emphasize quick recovery and balance.",
     "season_month": null,
+    "progression_stage": null,
+    "teaching_complexity": null,
+    "variant": null,
     "source": "u9-core-skills-e.pdf"
   }
   ```
 
   Return only the JSON block.
+  Also include:
+  - progression_stage: one of ["Introductory", "Developmental", "Refinement"]
+  - teaching_complexity: 1 (easy) to 3 (complex), based on how hard this is for the average player

--- a/prompts/ltad_stage3_normalize.yaml
+++ b/prompts/ltad_stage3_normalize.yaml
@@ -1,0 +1,12 @@
+prompt: |
+  You normalize and canonicalize LTADSkill objects for youth hockey development.
+  Review the given skill and adjust fields so they match the style of existing skills.
+  - Keep skill_name concise (e.g. "C-cuts").
+  - Move descriptors like "left", "right", "wide", "narrow", or "alternating" into the variant field.
+  - If age_group is missing, attempt to infer it from the filename in the source field (values like "U7", "U9", etc.).
+  - If ltad_stage is missing and age_group is provided, infer using:
+      U7 -> Fundamentals 1
+      U9 -> Fundamentals 2
+      U11 -> Learn to Train
+      U13 -> Train to Train
+  Return a single JSON object with the same LTADSkill fields.


### PR DESCRIPTION
## Summary
- add stage 3 prompt for normalization
- implement `normalize_ltad_skill` using OpenAI
- run new stage in `extract_ltad_skills.py`

## Testing
- `python -m py_compile scripts/extract_ltad_skills.py ltad_normalizer.py models/ltad.py`
- `python scripts/extract_ltad_skills.py --input-folder data/raw/ltad --output data/processed/ltad_skills_raw.json --normalize` *(fails: The api_key client option must be set either by passing api_key to the client or by setting the OPENAI_API_KEY environment variable)*

------
https://chatgpt.com/codex/tasks/task_e_686d38cbbd40832696d3805d0a87aa35