### PR TITLE
Add YouTubeSearchTool and integrate into video search

### DIFF
--- a/prompts/video_search_prompt.yaml
+++ b/prompts/video_search_prompt.yaml
@@ -1,11 +1,13 @@
 prompt: |
-  You are a hockey video assistant. Search the web for YouTube videos based on the user's request.
-  Always append "site:youtube.com" to the search query so that results come from YouTube only.
+  You are a hockey video assistant. Use the YouTube Data API to search for videos based on the user's request.
+  Only return video links retrieved from the API with real video IDs. Do not guess or fabricate video URLs.
   Return a short list of JSON objects containing:
     - `url`
     - `title` if available
     - `author` or uploader name
     - `channel` (the source channel name)
+    - `view_count`
+    - `published_at`
     - `rationale` explaining why the video is relevant
 
   Example:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,6 +25,7 @@ yt-dlp = "^2024.4.9"          # or omit version for latest
 openai-whisper = { git = "https://github.com/openai/whisper.git" }
 pandas = "^2.1.3"
 pymupdf = "^1.23.7"
+google-api-python-client = "^2.126.0"
 
 [build-system]
 requires = ["poetry-core"]

--- a/tools/youtube_search_tool.py
+++ b/tools/youtube_search_tool.py
@@ -1,0 +1,84 @@
+from __future__ import annotations
+
+import os
+from typing import List, Optional
+
+from pydantic import BaseModel
+from googleapiclient.discovery import build
+
+from agents.tool import function_tool
+
+
+class VideoResult(BaseModel):
+    """Video metadata returned from the YouTube Data API."""
+
+    url: str
+    title: Optional[str] | None = None
+    author: Optional[str] | None = None
+    channel: Optional[str] | None = None
+    view_count: Optional[int] | None = None
+    published_at: Optional[str] | None = None
+
+
+def _get_client():
+    api_key = os.getenv("YOUTUBE_API_KEY")
+    if not api_key:
+        raise RuntimeError("YOUTUBE_API_KEY environment variable not set")
+    return build("youtube", "v3", developerKey=api_key)
+
+
+@function_tool(
+    name_override="youtube_search",
+    description_override="Search YouTube videos using the official YouTube Data API",
+)
+def youtube_search(
+    query: str,
+    max_results: int = 5,
+    channel_id: Optional[str] = None,
+    videoCategoryId: Optional[str] = None,
+    order: Optional[str] = None,
+) -> List[VideoResult]:
+    """Return a list of YouTube videos matching the search query."""
+
+    youtube = _get_client()
+
+    search_kwargs = {
+        "part": "id",
+        "q": query,
+        "maxResults": max_results,
+        "type": "video",
+    }
+    if channel_id:
+        search_kwargs["channelId"] = channel_id
+    if videoCategoryId:
+        search_kwargs["videoCategoryId"] = videoCategoryId
+    if order:
+        search_kwargs["order"] = order
+
+    search_resp = youtube.search().list(**search_kwargs).execute()
+    video_ids = [item["id"]["videoId"] for item in search_resp.get("items", [])]
+    if not video_ids:
+        return []
+
+    videos_resp = (
+        youtube.videos()
+        .list(part="snippet,statistics", id=",".join(video_ids))
+        .execute()
+    )
+
+    results: List[VideoResult] = []
+    for item in videos_resp.get("items", []):
+        snippet = item.get("snippet", {})
+        stats = item.get("statistics", {})
+        results.append(
+            VideoResult(
+                url=f"https://www.youtube.com/watch?v={item['id']}",
+                title=snippet.get("title"),
+                author=snippet.get("channelTitle"),
+                channel=snippet.get("channelTitle"),
+                view_count=int(stats.get("viewCount")) if stats.get("viewCount") else None,
+                published_at=snippet.get("publishedAt"),
+            )
+        )
+
+    return results


### PR DESCRIPTION
## Summary
- add YouTubeSearchTool to call the YouTube Data API
- update video search agent to use the new tool
- extend prompt instructions to rely on YouTube API results
- require google-api-python-client dependency

## Testing
- `pip show google-api-python-client | head -n 5`
- `python - <<'PY'
import os, json, asyncio
from tools.youtube_search_tool import youtube_search
async def test():
    os.environ['YOUTUBE_API_KEY'] = 'invalid'
    try:
        res = await youtube_search.on_invoke_tool(None, json.dumps({'query':'test','max_results':1}))
        print('RES', res)
    except Exception as e:
        print('ERROR', type(e).__name__, e)
asyncio.run(test())
PY`
- `python -m app.client.agent.video_search_agent --query "hockey" --num 1 --output /tmp/out.json 2>&1 | head -n 20`

------
https://chatgpt.com/codex/tasks/task_e_686d46054f04832691aa89fc79bfa987