### PR TITLE
Refactor video tools to use YouTube API via MCP

### DIFF
--- a/app/mcp_server/server.py
+++ b/app/mcp_server/server.py
@@ -8,6 +8,9 @@ from chromadb.config import Settings
 import chromadb
 import os
 
+# Import video tools so they register with this MCP instance
+from . import video_tools  # noqa: F401
+
 mcp = FastMCP("Thunder DrillKB")
 
 # === Drill Schema Definition ===
@@ -143,7 +146,7 @@ def get_drill_schema() -> str:
 }"""
 
 # === Tool: Search drills in chroma vector DB ===
-from chroma_utils import get_chroma_collection
+from .chroma_utils import get_chroma_collection
 collection = get_chroma_collection()
 
 def parse_list(value: str) -> list[str]:

--- a/app/mcp_server/video_tools.py
+++ b/app/mcp_server/video_tools.py
@@ -1,0 +1,28 @@
+"""MCP tools for searching YouTube videos."""
+
+from __future__ import annotations
+from typing import List, Optional
+
+from .server import mcp
+from tools.youtube_search_tool import (
+    youtube_search as _youtube_search,
+    fetch_channel_videos as _fetch_channel_videos,
+    VideoResult,
+)
+
+
+@mcp.tool(title="Search YouTube Videos")
+def search_youtube_videos(query: str, max_results: int = 5) -> List[VideoResult]:
+    """Search YouTube videos."""
+    return _youtube_search(query=query, max_results=max_results)
+
+
+@mcp.tool(title="Fetch Channel Videos")
+def fetch_channel_videos(
+    channel_id: str,
+    sort: Optional[str] = None,
+    limit: Optional[int] = None,
+    keywords: Optional[List[str]] = None,
+) -> List[VideoResult]:
+    """Fetch videos from a specific YouTube channel."""
+    return _fetch_channel_videos(channel=channel_id, limit=limit, sort=sort, keywords=keywords)

--- a/tools/youtube_search_tool.py
+++ b/tools/youtube_search_tool.py
@@ -82,3 +82,141 @@ def youtube_search(
         )
 
     return results
+
+
+def _resolve_channel_id(channel: str) -> str:
+    """Return channel ID from handle or URL."""
+    youtube = _get_client()
+    if channel.startswith("UC"):
+        return channel
+    if channel.startswith("http"):
+        # attempt to parse /channel/ID or /@handle
+        try:
+            from urllib.parse import urlparse
+
+            parsed = urlparse(channel)
+            parts = [p for p in parsed.path.split("/") if p]
+            if "channel" in parts:
+                idx = parts.index("channel")
+                if idx + 1 < len(parts):
+                    return parts[idx + 1]
+            for part in parts:
+                if part.startswith("@"):  # handle
+                    channel = part
+                    break
+        except Exception:
+            pass
+    if channel.startswith("@"):  # handle
+        handle = channel.lstrip("@")
+        resp = (
+            youtube.search()
+            .list(q=handle, type="channel", part="snippet", maxResults=1)
+            .execute()
+        )
+        items = resp.get("items", [])
+        if items:
+            return items[0]["snippet"]["channelId"]
+    # fallback search by query
+    resp = (
+        youtube.search()
+        .list(q=channel, type="channel", part="snippet", maxResults=1)
+        .execute()
+    )
+    items = resp.get("items", [])
+    if not items:
+        raise ValueError(f"Unable to resolve channel id for {channel}")
+    return items[0]["snippet"]["channelId"]
+
+
+def fetch_channel_videos(
+    channel: str,
+    limit: int | None = None,
+    sort: str | None = None,
+    keywords: List[str] | None = None,
+) -> List[VideoResult]:
+    """Return videos from a channel using the YouTube Data API."""
+    youtube = _get_client()
+    channel_id = _resolve_channel_id(channel)
+
+    order = None
+    if sort == "recent":
+        order = "date"
+    elif sort == "popular":
+        order = "viewCount"
+
+    search_kwargs = {
+        "part": "id",
+        "channelId": channel_id,
+        "maxResults": min(limit or 50, 50),
+        "type": "video",
+    }
+    if order:
+        search_kwargs["order"] = order
+
+    videos: List[VideoResult] = []
+    next_page = None
+    remaining = limit
+    while True:
+        if next_page:
+            search_kwargs["pageToken"] = next_page
+        resp = youtube.search().list(**search_kwargs).execute()
+        ids = [it["id"]["videoId"] for it in resp.get("items", [])]
+        if not ids:
+            break
+
+        vid_resp = (
+            youtube.videos()
+            .list(part="snippet,statistics", id=",".join(ids))
+            .execute()
+        )
+        for item in vid_resp.get("items", []):
+            snippet = item.get("snippet", {})
+            stats = item.get("statistics", {})
+            title = snippet.get("title", "")
+            if keywords and not any(k.lower() in title.lower() for k in keywords):
+                continue
+            videos.append(
+                VideoResult(
+                    url=f"https://www.youtube.com/watch?v={item['id']}",
+                    title=title,
+                    author=snippet.get("channelTitle"),
+                    channel=snippet.get("channelTitle"),
+                    view_count=int(stats.get("viewCount")) if stats.get("viewCount") else None,
+                    published_at=snippet.get("publishedAt"),
+                )
+            )
+
+        if limit and len(videos) >= limit:
+            videos = videos[:limit]
+            break
+
+        next_page = resp.get("nextPageToken")
+        if not next_page or (limit and remaining and len(videos) >= limit):
+            break
+
+    return videos
+
+
+def get_video_metadata(video_id: str) -> VideoResult:
+    """Fetch metadata for a single video."""
+    youtube = _get_client()
+    resp = (
+        youtube.videos()
+        .list(part="snippet,statistics", id=video_id)
+        .execute()
+    )
+    items = resp.get("items", [])
+    if not items:
+        raise ValueError(f"No video found for id {video_id}")
+    item = items[0]
+    snippet = item.get("snippet", {})
+    stats = item.get("statistics", {})
+    return VideoResult(
+        url=f"https://www.youtube.com/watch?v={video_id}",
+        title=snippet.get("title"),
+        author=snippet.get("channelTitle"),
+        channel=snippet.get("channelTitle"),
+        view_count=int(stats.get("viewCount")) if stats.get("viewCount") else None,
+        published_at=snippet.get("publishedAt"),
+    )
+


### PR DESCRIPTION
## Summary
- add helper functions for channel search and metadata in `youtube_search_tool`
- update transcript processor to fetch video metadata via the YouTube API
- expose `search_youtube_videos` and `fetch_channel_videos` MCP tools
- register video tools in the MCP server
- refactor `video_search_agent` to call MCP tools remotely

## Testing
- `python -m py_compile app/mcp_server/server.py app/mcp_server/video_tools.py app/client/agent/video_search_agent.py scripts/process_video_transcripts.py tools/youtube_search_tool.py`
- `PYTHONPATH=. python app/client/agent/video_search_agent.py --query "defensive positioning drills for U11" --output data/input/video_index.json` *(fails: ModuleNotFoundError: No module named 'googleapiclient')*


------
https://chatgpt.com/codex/tasks/task_e_686d4ea7e27c83269c3ef9f4b340ff35