### PR TITLE
Add LTAD metadata fields and validator

### DIFF
--- a/scripts/index_ltad_chroma.py
+++ b/scripts/index_ltad_chroma.py
@@ -5,7 +5,6 @@ from __future__ import annotations
 import argparse
 import json
 from pathlib import Path
-import os
 import sys
 
 sys.path.append(str(Path(__file__).resolve().parent.parent))
@@ -15,28 +14,34 @@ from app.mcp_server.chroma_utils import get_client, _embed
 
 def doc_text(skill: dict) -> str:
     parts = [
-        f"Age Group: {skill.get('age_group', '')}",
-        f"Stage: {skill.get('ltad_stage', '')}",
-        f"Position: {', '.join(skill.get('position', []))}",
-        f"Category: {skill.get('skill_category', '')}",
-        f"Skill: {skill.get('skill_name', '')}",
-        skill.get("teaching_notes", ""),
-        f"Month: {skill.get('season_month', '')}",
+        f"Age Group: {skill.get('age_group') or ''}",
+        f"Stage: {skill.get('ltad_stage') or ''}",
+        f"Position: {', '.join(skill.get('position') or [])}",
+        f"Category: {skill.get('skill_category') or ''}",
+        f"Skill: {skill.get('skill_name') or ''}",
+        skill.get("teaching_notes") or "",
+        f"Month: {skill.get('season_month') or ''}",
     ]
     text = "\n".join([p for p in parts if p])
     return text[:16000]
 
 
 def metadata_for(skill: dict) -> dict:
+    def safe_str(val) -> str:
+        return val if isinstance(val, str) else ""
+
     return {
-        "age_group": skill.get("age_group", ""),
-        "ltad_stage": skill.get("ltad_stage", ""),
-        "position": "; ".join(skill.get("position", [])),
-        "skill_category": skill.get("skill_category", ""),
-        "skill_name": skill.get("skill_name", ""),
-        "teaching_notes": skill.get("teaching_notes", ""),
-        "season_month": skill.get("season_month", ""),
-        "source": skill.get("source", ""),
+        "age_group": safe_str(skill.get("age_group")),
+        "ltad_stage": safe_str(skill.get("ltad_stage")),
+        "position": "; ".join(skill.get("position") or []),
+        "skill_category": safe_str(skill.get("skill_category")),
+        "skill_name": safe_str(skill.get("skill_name")),
+        "teaching_notes": safe_str(skill.get("teaching_notes")),
+        "season_month": safe_str(skill.get("season_month")),
+        "progression_stage": safe_str(skill.get("progression_stage")),
+        "teaching_complexity": str(skill.get("teaching_complexity") or ""),
+        "variant": safe_str(skill.get("variant")),
+        "source": safe_str(skill.get("source")),
     }
 
 

--- a/scripts/validate_ltad_data.py
+++ b/scripts/validate_ltad_data.py
@@ -1,0 +1,59 @@
+#!/usr/bin/env python3
+"""Sanity check LTAD skill JSON before indexing."""
+
+from __future__ import annotations
+import argparse
+import json
+from pathlib import Path
+from typing import List
+
+REQUIRED_FIELDS = ["skill_name", "skill_category", "teaching_notes", "source"]
+
+
+def load_skills(path: Path) -> List[dict]:
+    with open(path, "r", encoding="utf-8") as f:
+        return json.load(f)
+
+
+def validate_skill(skill: dict, idx: int) -> bool:
+    errors: List[str] = []
+    for field in REQUIRED_FIELDS:
+        val = skill.get(field)
+        if val is None or (isinstance(val, str) and not val.strip()):
+            errors.append(f"missing {field}")
+    tc = skill.get("teaching_complexity")
+    if tc is not None and not isinstance(tc, int):
+        errors.append("teaching_complexity must be int or null")
+    pos = skill.get("position")
+    if pos is not None and not isinstance(pos, list):
+        errors.append("position must be a list or null")
+    if errors:
+        print(f"❌ Skill {idx}: {', '.join(errors)}")
+        return False
+    return True
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Validate LTAD skill JSON")
+    parser.add_argument(
+        "--input",
+        type=Path,
+        default=Path("data/processed/ltad_index.json"),
+        help="Path to skill JSON file",
+    )
+    args = parser.parse_args()
+
+    if not args.input.is_file():
+        print(f"❌ File not found: {args.input}")
+        return
+
+    skills = load_skills(args.input)
+    valid = 0
+    for idx, skill in enumerate(skills, 1):
+        if validate_skill(skill, idx):
+            valid += 1
+    print(f"✅ {valid}/{len(skills)} skills passed validation")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- update `index_ltad_chroma.py` to handle optional values and index the
  `progression_stage`, `teaching_complexity` and `variant` fields
- add `scripts/validate_ltad_data.py` to sanity‑check LTAD JSON files before
  indexing

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `python scripts/validate_ltad_data.py` *(fails: File not found)*

------
https://chatgpt.com/codex/tasks/task_e_686e89eebb148326a4bf96e8a8f014a0