### PR TITLE
Add chunked indexing for video clips

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,6 +26,7 @@ openai-whisper = { git = "https://github.com/openai/whisper.git" }
 pandas = "^2.1.3"
 pymupdf = "^1.23.7"
 google-api-python-client = "^2.126.0"
+more-itertools = "^10.1.0"
 
 [build-system]
 requires = ["poetry-core"]

--- a/scripts/index_video_clips_chroma.py
+++ b/scripts/index_video_clips_chroma.py
@@ -3,6 +3,8 @@ import json
 import argparse
 from pathlib import Path
 from urllib.parse import urlparse, parse_qs
+from more_itertools import chunked
+import tiktoken
 
 import sys
 sys.path.append(str(Path(__file__).resolve().parent.parent))
@@ -106,7 +108,15 @@ def main() -> None:
     parser = argparse.ArgumentParser(description="Index video clip JSON files into Chroma")
     parser.add_argument("--input-folder", type=Path, help="Folder containing clip JSON files")
     parser.add_argument("--input-files", nargs="*", type=Path, help="Specific clip JSON files")
+    parser.add_argument(
+        "--chunk-size",
+        type=int,
+        default=100,
+        help="Number of clips per indexing chunk",
+    )
     args = parser.parse_args()
+    chunk_size = args.chunk_size
+    enc = tiktoken.get_encoding("cl100k_base")
 
     files: list[Path] = []
     if args.input_folder:
@@ -126,11 +136,16 @@ def main() -> None:
     video_ids = set()
     query_terms: dict[str, int] = {}
     manifest: dict[str, dict] = {}
+    max_tokens = 0
 
     for clip in data:
-        docs.append(clip_text(clip))
+        text = clip_text(clip)
+        docs.append(text)
         meta = metadata_for(clip)
         metadatas.append(meta)
+        tokens = len(enc.encode(text))
+        if tokens > max_tokens:
+            max_tokens = tokens
         vid_id = clip.get("video_id") or extract_video_id(clip.get("video_url", ""))
         seg_id = clip.get("segment_id") or f"{vid_id}_{clip.get('segment_number', '')}"
         ids.append(f"video-{seg_id}")
@@ -148,7 +163,21 @@ def main() -> None:
             query_terms[term] = query_terms.get(term, 0) + 1
 
     if docs:
-        collection.add(documents=docs, metadatas=metadatas, ids=ids)
+        print(f"📏 Largest document has {max_tokens} tokens")
+        for i, (doc_chunk, meta_chunk, id_chunk) in enumerate(
+            zip(
+                chunked(docs, chunk_size),
+                chunked(metadatas, chunk_size),
+                chunked(ids, chunk_size),
+            )
+        ):
+            print(f"📦 Indexing chunk {i+1} with {len(doc_chunk)} clips...")
+            try:
+                collection.add(documents=doc_chunk, metadatas=meta_chunk, ids=id_chunk)
+            except Exception as e:
+                print(f"❌ Failed to index chunk {i+1}: {e}")
+                continue
+
         print("Count:", collection.count())
         results = collection.get(include=["documents", "metadatas"], limit=5)
         for i, doc in enumerate(results["documents"]):


### PR DESCRIPTION
## Summary
- enable chunked indexing for video clip docs
- print max token count using tiktoken
- expose `--chunk-size` CLI arg
- add `more-itertools` dependency

## Testing
- `python -m py_compile scripts/index_video_clips_chroma.py`
- `python scripts/index_video_clips_chroma.py --help` *(fails: CHROMA_OPENAI_API_KEY env var not set)*

------
https://chatgpt.com/codex/tasks/task_e_686ef0c4320883268311fdbc55ce34b9