### PR TITLE
Add MLHS article and insight extraction

### DIFF
--- a/models/mlhs_article.py
+++ b/models/mlhs_article.py
@@ -16,3 +16,4 @@ class MLHSArticle(BaseModel):
     category: Optional[str]
     excerpt: Optional[str]
     html_content: str
+    page_number: int

--- a/models/nhl_insight.py
+++ b/models/nhl_insight.py
@@ -1,0 +1,24 @@
+from __future__ import annotations
+
+from datetime import date
+from typing import List, Optional
+
+from pydantic import BaseModel, HttpUrl
+
+
+class NHLInsight(BaseModel):
+    """Structured insight extracted from an NHL article."""
+
+    id: str
+    speaker: Optional[str] = None
+    quote: str
+    question: Optional[str] = None
+    context: Optional[str] = None
+    tags: List[str]
+    takeaways_for_coach: Optional[str] = None
+    takeaways_for_player: Optional[str] = None
+    source_url: HttpUrl
+    source_article: str
+    source_type: str = "MLHS"
+    published_date: date
+    author: Optional[str] = None

--- a/prompts/nhl_insight_extraction.txt
+++ b/prompts/nhl_insight_extraction.txt
@@ -1,0 +1,13 @@
+You are a hockey journalism analyst. Extract notable quotes, Q&A pairs, and coaching insights from the given Maple Leafs Hot Stove article HTML. 
+
+Return JSON list where each item contains:
+- id (generate a UUID if not provided)
+- speaker
+- quote
+- question
+- context
+- tags (list of words)
+- takeaways_for_coach
+- takeaways_for_player
+
+Respond with JSON only.

--- a/scripts/extract_mlhs_articles.py
+++ b/scripts/extract_mlhs_articles.py
@@ -7,7 +7,7 @@ import json
 import sys
 from datetime import datetime
 from pathlib import Path
-from typing import List
+from typing import List, Set
 
 import requests
 from bs4 import BeautifulSoup
@@ -21,6 +21,16 @@ BASE_URL = "https://mapleleafshotstove.com/leafs-news/"
 HEADERS = {
     "User-Agent": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/119.0 Safari/537.36"
 }
+
+
+def _load_json_if_exists(path: Path) -> list[dict]:
+    if path.exists():
+        try:
+            with open(path, "r", encoding="utf-8") as f:
+                return json.load(f)
+        except Exception:
+            return []
+    return []
 
 
 def fetch_page(url: str) -> BeautifulSoup:
@@ -41,11 +51,14 @@ def parse_tiles(soup: BeautifulSoup) -> List[dict]:
         date_el = div.select_one("span.td-post-date")
         cat_el = div.select_one("a.td-post-category")
         excerpt_el = div.select_one("div.td-excerpt")
+        author = author_el.get_text(strip=True) if author_el else None
+        if author and author.endswith("-"):
+            author = author[:-1].strip()
         tiles.append(
             {
                 "title": title,
                 "url": url,
-                "author": author_el.get_text(strip=True) if author_el else None,
+                "author": author,
                 "published_date": date_el.get_text(strip=True) if date_el else None,
                 "category": cat_el.get_text(strip=True) if cat_el else None,
                 "excerpt": excerpt_el.get_text(strip=True) if excerpt_el else None,
@@ -60,7 +73,7 @@ def fetch_article_html(url: str) -> str:
     return str(content_div) if content_div else ""
 
 
-def crawl(num_pages: int) -> List[MLHSArticle]:
+def crawl(num_pages: int, existing_urls: Set[str]) -> List[MLHSArticle]:
     articles: List[MLHSArticle] = []
     for page in range(1, num_pages + 1):
         page_url = BASE_URL if page == 1 else f"{BASE_URL}page/{page}/"
@@ -69,21 +82,33 @@ def crawl(num_pages: int) -> List[MLHSArticle]:
         tiles = parse_tiles(soup)
         print(f"📝 Found {len(tiles)} articles on page {page}")
         for t in tiles:
+            if t["url"] in existing_urls:
+                print(f"⏭️ Skipping already fetched {t['url']}")
+                continue
             html = fetch_article_html(t["url"])
             try:
-                date_obj = datetime.strptime(t["published_date"], "%B %d, %Y").date() if t.get("published_date") else datetime.today().date()
+                date_obj = (
+                    datetime.strptime(t["published_date"], "%B %d, %Y").date()
+                    if t.get("published_date")
+                    else datetime.today().date()
+                )
             except Exception:
                 date_obj = datetime.today().date()
+            author = t.get("author")
+            if author and author.endswith("-"):
+                author = author[:-1].strip()
             article = MLHSArticle(
                 title=t["title"],
                 url=t["url"],
-                author=t.get("author"),
+                author=author,
                 published_date=date_obj,
                 category=t.get("category"),
                 excerpt=t.get("excerpt"),
                 html_content=html,
+                page_number=page,
             )
             articles.append(article)
+            existing_urls.add(t["url"])
     return articles
 
 
@@ -95,14 +120,30 @@ def write_output(articles: List[MLHSArticle], out_path: Path) -> None:
 
 
 def main() -> None:
-    parser = argparse.ArgumentParser(description="Extract Maple Leafs Hot Stove articles")
-    parser.add_argument("--num-pages", type=int, default=1, help="Number of pages to crawl")
-    parser.add_argument("--output", type=Path, default=Path("data/raw/mlhs_articles.json"), help="Output JSON path")
+    parser = argparse.ArgumentParser(
+        description="Extract Maple Leafs Hot Stove articles"
+    )
+    parser.add_argument(
+        "--num-pages", type=int, default=1, help="Number of pages to crawl"
+    )
+    parser.add_argument(
+        "--output",
+        type=Path,
+        default=Path("data/raw/mlhs_articles.json"),
+        help="Output JSON path",
+    )
     args = parser.parse_args()
 
-    articles = crawl(args.num_pages)
+    existing_data = _load_json_if_exists(args.output)
+    existing_urls = {a.get("url") for a in existing_data}
+    articles = [MLHSArticle(**a) for a in existing_data]
+
+    new_articles = crawl(args.num_pages, existing_urls)
+    articles.extend(new_articles)
     write_output(articles, args.output)
-    print(f"✅ Saved {len(articles)} articles to {args.output}")
+    print(
+        f"✅ Saved {len(new_articles)} new articles ({len(articles)} total) to {args.output}"
+    )
 
 
 if __name__ == "__main__":

--- a/scripts/process_mlhs_insights.py
+++ b/scripts/process_mlhs_insights.py
@@ -1,0 +1,149 @@
+#!/usr/bin/env python3
+"""Process Maple Leafs Hot Stove articles with LLM to extract coaching insights."""
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+from typing import List, Set
+from uuid import uuid4
+
+from openai import OpenAI
+
+sys.path.append(str(Path(__file__).resolve().parent.parent))
+
+from models.mlhs_article import MLHSArticle
+from models.nhl_insight import NHLInsight
+
+client = OpenAI()
+PROMPT_PATH = (
+    Path(__file__).resolve().parent.parent / "prompts" / "nhl_insight_extraction.txt"
+)
+with open(PROMPT_PATH, "r", encoding="utf-8") as f:
+    INSIGHT_PROMPT = f.read()
+
+
+# ---------------------------------------------------------------------------
+# Utils
+# ---------------------------------------------------------------------------
+
+
+def _parse_json(content: str):
+    try:
+        if content.startswith("```json"):
+            content = content.split("```json", 1)[1].split("```", 1)[0]
+        return json.loads(content)
+    except Exception:
+        return None
+
+
+def _load_json_if_exists(path: Path) -> list[dict]:
+    if path.exists():
+        try:
+            with open(path, "r", encoding="utf-8") as f:
+                return json.load(f)
+        except Exception:
+            return []
+    return []
+
+
+def load_articles(path: Path) -> List[MLHSArticle]:
+    data = _load_json_if_exists(path)
+    return [MLHSArticle(**d) for d in data]
+
+
+def load_existing_insights(path: Path) -> tuple[List[NHLInsight], Set[str]]:
+    raw = _load_json_if_exists(path)
+    insights: List[NHLInsight] = []
+    urls: Set[str] = set()
+    for d in raw:
+        try:
+            obj = NHLInsight(**d)
+            insights.append(obj)
+            urls.add(str(obj.source_url))
+        except Exception:
+            continue
+    return insights, urls
+
+
+def extract_insights_llm(article: MLHSArticle) -> List[NHLInsight]:
+    user = f"ARTICLE HTML:\n{article.html_content}"
+    resp = client.chat.completions.create(
+        model="gpt-3.5-turbo-0125",
+        temperature=0,
+        messages=[
+            {"role": "system", "content": INSIGHT_PROMPT},
+            {"role": "user", "content": user},
+        ],
+    )
+    data = _parse_json(resp.choices[0].message.content)
+    if not data:
+        return []
+    if isinstance(data, dict):
+        data = [data]
+    insights: List[NHLInsight] = []
+    for d in data:
+        d.setdefault("id", str(uuid4()))
+        d.setdefault("source_url", str(article.url))
+        d.setdefault("source_article", article.title)
+        d.setdefault("source_type", "MLHS")
+        d.setdefault("published_date", str(article.published_date))
+        d.setdefault("author", article.author)
+        try:
+            insights.append(NHLInsight(**d))
+        except Exception:
+            continue
+    return insights
+
+
+# ---------------------------------------------------------------------------
+# CLI
+# ---------------------------------------------------------------------------
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description="Process MLHS articles for NHL insights"
+    )
+    parser.add_argument(
+        "--input", type=Path, default=Path("data/raw/mlhs_articles.json")
+    )
+    parser.add_argument(
+        "--output", type=Path, default=Path("data/processed/mlhs_insights.json")
+    )
+    parser.add_argument(
+        "--max-articles",
+        type=int,
+        default=0,
+        help="Limit number of articles to process",
+    )
+    args = parser.parse_args()
+
+    articles = load_articles(args.input)
+    existing, processed_urls = load_existing_insights(args.output)
+    print(
+        f"✅ Loaded {len(articles)} articles; {len(existing)} insights already processed"
+    )
+
+    to_process = [a for a in articles if str(a.url) not in processed_urls]
+    if args.max_articles:
+        to_process = to_process[: args.max_articles]
+
+    new_insights: List[NHLInsight] = []
+    for art in to_process:
+        print(f"✨ Processing: {art.title}")
+        new_insights.extend(extract_insights_llm(art))
+
+    all_insights = [i.model_dump() for i in existing + new_insights]
+    args.output.parent.mkdir(parents=True, exist_ok=True)
+    with open(args.output, "w", encoding="utf-8") as f:
+        json.dump(all_insights, f, indent=2)
+
+    print(
+        f"✅ Wrote {len(new_insights)} new insights ({len(all_insights)} total) to {args.output}"
+    )
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- scrape Maple Leafs Hot Stove article HTML and skip duplicates
- capture `page_number` in each article entry
- model NHLInsight records
- add process_mlhs_insights.py to call an LLM with a prompt
- add nhl_insight_extraction prompt

## Testing
- `ruff check scripts/process_mlhs_insights.py scripts/extract_mlhs_articles.py models/nhl_insight.py models/mlhs_article.py --fix`
- `python -m py_compile scripts/extract_mlhs_articles.py scripts/process_mlhs_insights.py models/nhl_insight.py models/mlhs_article.py`
- *(scrape test failed: Tunnel connection failed 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_686eeca21b588326be2b6a7987e51bd8