### PR TITLE
Refactor off‑ice extractor to use Pydantic model

### DIFF
--- a/models/off_ice.py
+++ b/models/off_ice.py
@@ -1,0 +1,17 @@
+from __future__ import annotations
+
+from typing import Optional, List
+from pydantic import BaseModel
+
+class OffIceEntry(BaseModel):
+    title: str
+    category: str
+    description: str
+    source_page: int
+    source: str = "off_ice_manual_hockey_canada_level1"
+
+    age_recommendation: Optional[str] = None
+    goals: Optional[List[str]] = None
+
+    def is_valid(self) -> bool:
+        return all([self.title.strip(), self.category.strip(), self.description.strip()])


### PR DESCRIPTION
## Summary
- model new `OffIceEntry` in `models/off_ice.py`
- refactor `extract_office_manual.py` to build and validate `OffIceEntry`
- deduplicate and serialize using `OffIceEntry.dict()`

## Testing
- `poetry run pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686fdb4f325483269c2aad72f9e86d77