### PR TITLE
Add off-ice enrichment pipeline

### DIFF
--- a/models/enriched_off_ice.py
+++ b/models/enriched_off_ice.py
@@ -1,0 +1,22 @@
+from __future__ import annotations
+
+from typing import List, Optional
+from pydantic import BaseModel
+
+class EnrichedOffIceEntry(BaseModel):
+    """Off-ice manual entry with additional metadata for indexing."""
+
+    title: str
+    category: str
+    description: str
+    source_pages: List[int]
+    source: str = "off_ice_manual_hockey_canada_level1"
+
+    age_recommendation: Optional[str] = None
+    goals: Optional[List[str]] = None
+
+    focus_area: str
+    teaching_complexity: str
+    progression_stage: str
+    equipment_needed: Optional[str] = None
+    safety_notes: Optional[str] = None

--- a/prompts/office_stage1_merge_enrich.yaml
+++ b/prompts/office_stage1_merge_enrich.yaml
@@ -1,0 +1,18 @@
+prompt: |
+  You merge multiple off-ice training entries into a single consolidated drill.
+  Combine overlapping descriptions, remove duplicates, and keep important details.
+  Fill the following fields when possible:
+    title
+    category
+    description
+    age_recommendation
+    goals
+    focus_area
+    teaching_complexity
+    progression_stage
+    equipment_needed
+    safety_notes
+    source_pages
+  teaching_complexity is 1 (easy) to 3 (complex).
+  progression_stage is one of ["Introductory", "Developmental", "Refinement"].
+  Return only one JSON object.

--- a/scripts/extract_office_manual.py
+++ b/scripts/extract_office_manual.py
@@ -6,7 +6,10 @@ import argparse
 import json
 import sys
 from pathlib import Path
-from typing import List
+from typing import List, Dict
+
+import re
+from difflib import SequenceMatcher
 
 from pydantic import ValidationError
 
@@ -17,11 +20,13 @@ from openai import OpenAI
 sys.path.append(str(Path(__file__).resolve().parent.parent))
 
 from models.off_ice import OffIceEntry
+from models.enriched_off_ice import EnrichedOffIceEntry
 
 client = OpenAI()
 
 PROMPT_DIR = Path(__file__).resolve().parent.parent / "prompts"
 PROMPT_STAGE0 = PROMPT_DIR / "office_stage0_extract.yaml"
+PROMPT_STAGE1 = PROMPT_DIR / "office_stage1_merge_enrich.yaml"
 
 
 def load_prompt(path: Path) -> str:
@@ -31,6 +36,7 @@ def load_prompt(path: Path) -> str:
 
 
 PROMPT = load_prompt(PROMPT_STAGE0)
+PROMPT_MERGE = load_prompt(PROMPT_STAGE1)
 
 
 def _parse_json(content: str) -> list[dict] | dict | None:
@@ -91,6 +97,50 @@ def dedupe(items: List[OffIceEntry]) -> List[OffIceEntry]:
     return result
 
 
+def _norm(text: str) -> str:
+    text = re.sub(r"[^a-z0-9]+", " ", text.lower()).strip()
+    return text
+
+
+def group_similar(items: List[OffIceEntry]) -> List[List[OffIceEntry]]:
+    """Group entries with fuzzy-matched titles for merging."""
+    groups: List[List[OffIceEntry]] = []
+    used: set[int] = set()
+    titles = [_norm(it.title) for it in items]
+    for i, it in enumerate(items):
+        if i in used:
+            continue
+        grp = [it]
+        used.add(i)
+        for j in range(i + 1, len(items)):
+            if j in used:
+                continue
+            if SequenceMatcher(None, titles[i], titles[j]).ratio() >= 0.85:
+                grp.append(items[j])
+                used.add(j)
+        groups.append(grp)
+    return groups
+
+
+def merge_and_enrich(group: List[OffIceEntry]) -> EnrichedOffIceEntry | None:
+    """Use the LLM to merge similar entries and enrich metadata."""
+    user = json.dumps([e.model_dump() for e in group], indent=2)
+    resp = client.chat.completions.create(
+        model="gpt-3.5-turbo-0125",
+        temperature=0,
+        messages=[{"role": "system", "content": PROMPT_MERGE}, {"role": "user", "content": user}],
+    )
+    data = _parse_json(resp.choices[0].message.content)
+    if isinstance(data, dict):
+        data.setdefault("source_pages", sorted({e.source_page for e in group}))
+        data.setdefault("source", group[0].source)
+        try:
+            return EnrichedOffIceEntry(**data)
+        except ValidationError as e:
+            print(f"❌ Validation error: {e}")
+    return None
+
+
 def extract_pdf(pdf_path: Path) -> List[OffIceEntry]:
     doc = fitz.open(pdf_path)
     rows: List[OffIceEntry] = []
@@ -105,42 +155,63 @@ def extract_pdf(pdf_path: Path) -> List[OffIceEntry]:
 
 
 def main() -> None:
-    parser = argparse.ArgumentParser(description="Extract off-ice manual content")
+    parser = argparse.ArgumentParser(
+        description="Process off-ice manual entries with optional PDF extraction"
+    )
     parser.add_argument(
         "--input",
         type=Path,
-        default=Path("data/raw/off_ice_manual_level1.pdf"),
-        help="Input PDF file",
+        default=Path("data/raw/off_ice_raw.json"),
+        help="Input JSON file from stage 0",
     )
     parser.add_argument(
         "--output",
         type=Path,
-        default=Path("data/raw/off_ice_raw.json"),
-        help="Output JSON file",
+        default=Path("data/processed/off_ice_enriched.json"),
+        help="Output enriched JSON file",
+    )
+    parser.add_argument(
+        "--pdf",
+        type=Path,
+        help="Optional PDF path to re-run stage 0 extraction",
     )
     parser.add_argument("--dry-run", action="store_true", help="Print results only")
     args = parser.parse_args()
 
-    entries = extract_pdf(args.input)
+    raw_entries: List[OffIceEntry] = []
+    if args.pdf:
+        print(f"📖 Extracting from {args.pdf}")
+        raw_entries = extract_pdf(args.pdf)
+        args.input.parent.mkdir(parents=True, exist_ok=True)
+        with open(args.input, "w", encoding="utf-8") as f:
+            json.dump([e.model_dump() for e in raw_entries], f, indent=2)
+        print(f"✅ Wrote {len(raw_entries)} raw entries to {args.input}")
+    else:
+        for d in _load_json_if_exists(args.input):
+            try:
+                raw_entries.append(OffIceEntry(**d))
+            except ValidationError as e:
+                print(f"❌ Invalid raw entry: {e}")
 
-    if args.dry_run:
-        print(json.dumps([e.dict() for e in entries], indent=2))
+    if not raw_entries:
+        print("❌ No entries to process")
         return
 
-    existing_raw = _load_json_if_exists(args.output)
-    existing: List[OffIceEntry] = []
-    for d in existing_raw:
-        try:
-            existing.append(OffIceEntry(**d))
-        except ValidationError as e:
-            print(f"❌ Validation error for existing entry: {e}")
+    groups = group_similar(raw_entries)
+    enriched: List[EnrichedOffIceEntry] = []
+    for grp in groups:
+        item = merge_and_enrich(grp)
+        if item:
+            enriched.append(item)
 
-    existing.extend(entries)
-    existing = dedupe(existing)
+    if args.dry_run:
+        print(json.dumps([e.model_dump() for e in enriched], indent=2))
+        return
+
     args.output.parent.mkdir(parents=True, exist_ok=True)
     with open(args.output, "w", encoding="utf-8") as f:
-        json.dump([e.dict() for e in existing], f, indent=2)
-    print(f"✅ Wrote {len(existing)} entries to {args.output}")
+        json.dump([e.model_dump() for e in enriched], f, indent=2)
+    print(f"✅ Wrote {len(enriched)} enriched entries to {args.output}")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- enrich off-ice manual extraction with merge and metadata stages
- define `EnrichedOffIceEntry` model
- add LLM prompt for merging and enriching off-ice entries

## Testing
- `python -m py_compile scripts/extract_office_manual.py models/enriched_off_ice.py`
- `python scripts/extract_office_manual.py --dry-run` *(fails: OpenAI API key not provided)*

------
https://chatgpt.com/codex/tasks/task_e_686ff4c9be388326b3486438b43f0137