### PR TITLE
Improve LTAD index pipeline merging and logging

### DIFF
--- a/app/mcp_server/ltad_tools.py
+++ b/app/mcp_server/ltad_tools.py
@@ -15,7 +15,7 @@ LTAD_PATH = Path(__file__).resolve().parent.parent / "data" / "processed" / "lta
 
 
 class LTADSkill(TypedDict):
-    age_group: str
+    age_groups: List[str]
     ltad_stage: str | None
     position: List[str]
     skill_category: str
@@ -36,7 +36,7 @@ def _load_data() -> List[LTADSkill]:
 def get_skills_by_age(age_group: str) -> List[LTADSkill]:
     """Return LTAD skills for a specific age group."""
     data = _load_data()
-    return [s for s in data if s.get("age_group") == age_group]
+    return [s for s in data if age_group in s.get("age_groups", [])]
 
 
 @mcp.tool("get_skills_by_position")

--- a/data/processed/ltad_skills_final.json
+++ b/data/processed/ltad_skills_final.json
@@ -1,0 +1,32 @@
+[
+  {
+    "skill_name": "C-cuts",
+    "skill_category": "Skating",
+    "variant": "alternating",
+    "ltad_stage": "Fundamentals 1",
+    "position": ["Any"],
+    "teaching_notes": "Used to develop early edge control and rhythm.",
+    "age_groups": ["U7"],
+    "source": "u7-core-skills-e.pdf"
+  },
+  {
+    "skill_name": "Pivots",
+    "skill_category": "Skating",
+    "variant": "forward to backward",
+    "ltad_stage": "Fundamentals 2",
+    "position": ["Any"],
+    "teaching_notes": "Transition quickly while maintaining balance.",
+    "age_groups": ["U9"],
+    "source": "u9-core-skills-e.pdf"
+  },
+  {
+    "skill_name": "Figure 8's",
+    "skill_category": "Skating",
+    "variant": "circle",
+    "ltad_stage": "Fundamentals 1",
+    "position": ["Any"],
+    "teaching_notes": "Focus on edge control around each loop.",
+    "age_groups": ["U7", "U9"],
+    "source": "u7-core-skills-e.pdf"
+  }
+]

--- a/scripts/index_ltad_chroma.py
+++ b/scripts/index_ltad_chroma.py
@@ -13,8 +13,9 @@ from app.mcp_server.chroma_utils import get_client, _embed
 
 
 def doc_text(skill: dict) -> str:
+    ags = ', '.join(skill.get('age_groups') or [])
     parts = [
-        f"Age Group: {skill.get('age_group') or ''}",
+        f"Age Groups: {ags}",
         f"Stage: {skill.get('ltad_stage') or ''}",
         f"Position: {', '.join(skill.get('position') or [])}",
         f"Category: {skill.get('skill_category') or ''}",
@@ -31,7 +32,7 @@ def metadata_for(skill: dict) -> dict:
         return val if isinstance(val, str) else ""
 
     return {
-        "age_group": safe_str(skill.get("age_group")),
+        "age_groups": "; ".join(skill.get("age_groups") or []),
         "ltad_stage": safe_str(skill.get("ltad_stage")),
         "position": "; ".join(skill.get("position") or []),
         "skill_category": safe_str(skill.get("skill_category")),


### PR DESCRIPTION
## Summary
- support `age_groups` field across pipeline
- normalize variants and drop `age_group`
- add progress logging in generate_ltad_skill_index
- update indexing scripts for new metadata schema
- provide sample processed skills JSON

## Testing
- `python -m py_compile scripts/generate_ltad_skill_index.py scripts/index_ltad_chroma.py app/mcp_server/ltad_tools.py`
- `python scripts/validate_ltad_data.py --input data/processed/ltad_skills_final.json`
- `python scripts/generate_ltad_skill_index.py --input-folder data/raw/ltad --output data/processed/ltad_skills_final.json` *(fails: OpenAI API key missing)*

------
https://chatgpt.com/codex/tasks/task_e_6870239607cc832684a3d81823e061c3