### PR TITLE
Align conduct indexer with shared Chroma utilities

### DIFF
--- a/scripts/index_conduct_chroma.py
+++ b/scripts/index_conduct_chroma.py
@@ -2,6 +2,7 @@
 """Index conduct entries into a Chroma collection."""
 
 from __future__ import annotations
+
 import argparse
 import json
 from pathlib import Path
@@ -9,9 +10,7 @@ import sys
 
 sys.path.append(str(Path(__file__).resolve().parent.parent))
 
-from app.mcp_server.chroma_utils import get_client, _embed
-
-COLLECTION_NAME = "conduct_index"
+from app.mcp_server.chroma_utils import get_chroma_collection
 
 
 def doc_text(entry: dict) -> str:
@@ -27,38 +26,62 @@ def metadata_for(entry: dict) -> dict:
         "document_type": s(entry.get("document_type")),
         "source": s(entry.get("source")),
         "page": str(entry.get("page") or ""),
+        "type": "conduct_policy",
     }
-
-
-def clear_collection(coll) -> None:
-    ids = coll.get().get("ids", [])
-    if ids:
-        coll.delete(ids=ids)
-        print(f"🧹 Cleared {len(ids)} documents")
 
 
 def main() -> None:
     parser = argparse.ArgumentParser(description="Index conduct entries")
-    parser.add_argument("--input", type=Path, default=Path("data/processed/conduct_enriched.json"))
+    parser.add_argument("--input", type=Path, default=Path("data/processed/conduct_enriched.json"), help="Path to conduct_enriched.json")
+    parser.add_argument("--dry-run", action="store_true", help="Print summary without indexing")
+    parser.add_argument("--limit", type=int, help="Only index first N entries")
     args = parser.parse_args()
 
     with open(args.input, "r", encoding="utf-8") as f:
         data = json.load(f)
 
-    client = get_client()
-    collection = client.get_or_create_collection(COLLECTION_NAME, embedding_function=_embed)
-    clear_collection(collection)
+    if args.limit:
+        data = data[: args.limit]
+    print(f"📂 Loaded {len(data)} entries from {args.input}")
 
-    docs = [doc_text(e) for e in data]
-    metas = [metadata_for(e) for e in data]
-    ids = [f"conduct-{i}" for i in range(len(data))]
+    collection = get_chroma_collection()
+    existing = set(collection.get().get("ids", []))
 
-    if docs:
-        collection.add(documents=docs, metadatas=metas, ids=ids)
-        print("Count:", collection.count())
-        print(f"✅ Indexed {len(docs)} conduct entries into Chroma")
-    else:
-        print("No entries to index")
+    indexed = 0
+    skipped = 0
+
+    for idx, entry in enumerate(data):
+        doc_id = f"conduct-{idx}"
+        title = entry.get("title") or ""
+        content = entry.get("content") or ""
+
+        if doc_id in existing:
+            print(f"⏭️  Skipping {doc_id}: already indexed")
+            skipped += 1
+            continue
+
+        if not (title and content):
+            print(f"⚠️ Skipping {doc_id}: missing title or content")
+            skipped += 1
+            continue
+
+        print(f"Indexing {doc_id}: {title}")
+        if args.dry_run:
+            indexed += 1
+            continue
+
+        try:
+            collection.add(documents=[doc_text(entry)], metadatas=[metadata_for(entry)], ids=[doc_id])
+            indexed += 1
+        except Exception as e:
+            print(f"❌ Failed to index {doc_id}: {e}")
+            skipped += 1
+
+    print(f"✅ Indexed {indexed} entries, skipped {skipped}")
+    try:
+        print("Final collection count:", collection.count())
+    except Exception as e:
+        print(f"❌ Could not retrieve collection count: {e}")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- use `get_chroma_collection` for conduct entries
- include `type: conduct_policy` metadata
- add `--dry-run` and `--limit` options and skip bad rows
- prevent wiping other documents when indexing

## Testing
- `python -m py_compile scripts/index_conduct_chroma.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6870743c29f483268067aea6ba08f7e4