### PR TITLE
Fix conduct index normalization

### DIFF
--- a/scripts/generate_conduct_index.py
+++ b/scripts/generate_conduct_index.py
@@ -142,6 +142,15 @@ def normalize(entry: dict) -> dict:
         "page": entry.get("page"),
     }
     norm = {**defaults, **entry}
+
+    # Coerce list values into strings for schema validation
+    for key in ["title", "content", "role", "topic", "document_type"]:
+        value = norm.get(key)
+        if isinstance(value, list):
+            norm[key] = " ".join(str(v).strip() for v in value if v)
+        elif value is not None:
+            norm[key] = str(value).strip()
+
     return ConductEntry(**norm).model_dump()
 
 


### PR DESCRIPTION
## Summary
- normalize list values from LLM output before validation

## Testing
- `pytest -q`
- `python -m py_compile scripts/generate_conduct_index.py`


------
https://chatgpt.com/codex/tasks/task_e_68707f86c8c88326aa5c525492db27dd