### PR TITLE
Fix elicitation flow using FastMCP

### DIFF
--- a/app/client/agent/manager_agent.py
+++ b/app/client/agent/manager_agent.py
@@ -1,0 +1,45 @@
+from __future__ import annotations
+
+"""Manager agent demonstrating an elicitation flow."""
+
+from uuid import uuid4
+from pydantic import BaseModel
+from agents import Agent, Runner
+from agents.mcp import MCPServerSse
+
+
+class ManagerOutput(BaseModel):
+    plan: str
+
+
+def _instructions() -> str:
+    return (
+        "You plan a short hockey practice. "
+        "If no skill focus is provided, call `mcp_elicitation_tool` with the given session_id. "
+        "Once a skill is returned, acknowledge it in your plan."
+    )
+
+
+manager_agent = Agent(
+    name="PracticeManager",
+    instructions=_instructions(),
+    output_type=ManagerOutput,
+    mcp_servers=[MCPServerSse(name="ToolServer", params={"url": "http://localhost:8000/sse"})],
+    model="gpt-4o",
+)
+
+
+class ManagerRunner:
+    def __init__(self, server: MCPServerSse | None = None) -> None:
+        if server:
+            manager_agent.mcp_servers = [server]
+
+    async def run(self, goal: str, skill: str | None = None, session_id: str | None = None) -> ManagerOutput:
+        session_id = session_id or str(uuid4())
+        input_text = (
+            f"Goal: {goal}\n"
+            f"Skill focus: {skill or ''}\n"
+            f"Session: {session_id}"
+        )
+        result = await Runner.run(manager_agent, input_text)
+        return result.final_output_as(ManagerOutput)

--- a/app/client/app.py
+++ b/app/client/app.py
@@ -1,0 +1,48 @@
+from __future__ import annotations
+
+"""CLI demo that interacts with the elicitation tool."""
+
+import asyncio
+import subprocess
+import time
+from typing import Any
+
+from fastmcp import Client
+from fastmcp.client.elicitation import ElicitResult
+
+
+async def basic_elicitation_handler(
+    message: str, response_type: type, params: Any, context: Any
+) -> Any:
+    """Simple handler that collects user input from the console."""
+    print(f"\n🧠 Server asks: {message}")
+    user_response = input("📝 Your response: ").strip()
+
+    if not user_response:
+        return ElicitResult(action="decline")
+
+    return response_type(value=user_response)
+
+
+async def run_demo() -> None:
+    client = Client(
+        "http://localhost:8000",
+        elicitation_handler=basic_elicitation_handler,
+    )
+
+    response = await client.invoke("Choose Skill Focus")
+    print(f"\n✅ Final Output: {response.output}")
+
+
+def main() -> None:
+    proc = subprocess.Popen(["uvicorn", "app.mcp_server.toolserver:app"])
+    time.sleep(1)
+
+    try:
+        asyncio.run(run_demo())
+    finally:
+        proc.terminate()
+
+
+if __name__ == "__main__":
+    main()

--- a/app/mcp_server/elicitation_tool.py
+++ b/app/mcp_server/elicitation_tool.py
@@ -1,0 +1,26 @@
+from __future__ import annotations
+
+"""FastMCP tool demonstrating the `ctx.elicit` flow."""
+
+from typing import Literal
+
+from fastmcp import FastMCP, Context
+
+
+mcp = FastMCP("Thunder Elicitation Server")
+
+
+@mcp.tool(title="Choose Skill Focus")
+async def choose_skill_focus(ctx: Context) -> str:
+    """Ask the user to choose a skill focus area."""
+    result = await ctx.elicit(
+        message="Which skill do you want to focus on?",
+        response_type=Literal["Skating", "Passing", "Backchecking", "Shooting"],
+    )
+
+    if result.action == "accept":
+        return f"Great choice! We'll focus on {result.data}."
+    elif result.action == "decline":
+        return "No skill selected."
+    else:
+        return "Operation cancelled."

--- a/app/mcp_server/toolserver.py
+++ b/app/mcp_server/toolserver.py
@@ -1,0 +1,29 @@
+from __future__ import annotations
+
+"""Minimal FastMCP server exposing the ElicitationTool."""
+
+from fastapi import Request
+from fastmcp.server.fastmcp import FastMCP
+from fastmcp.server.http import create_sse_app
+import uvicorn
+
+from .elicitation_tool import mcp as elicitation_mcp, responses
+
+# Compose tool server with elicitation tool registered
+server = FastMCP("ToolServer", tools=[elicitation_mcp])
+
+app = create_sse_app(server, message_path="/messages", sse_path="/sse")
+
+
+@app.post("/submit")
+async def submit(req: Request) -> dict[str, str]:
+    data = await req.json()
+    session_id = data.get("session_id")
+    answer = data.get("response")
+    if session_id and answer:
+        responses[session_id] = answer
+    return {"status": "ok"}
+
+
+if __name__ == "__main__":
+    uvicorn.run(app, host="0.0.0.0", port=8000)


### PR DESCRIPTION
## Summary
- replace custom prompt logic with `ctx.elicit` in the FastMCP tool
- add client `elicitation_handler` callback using `fastmcp.Client`

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_687085bc5af483268d1d9031c6b0d6e3