### PR TITLE
Add off-ice search MVP

### DIFF
--- a/app/client/agent/off_ice_planner.py
+++ b/app/client/agent/off_ice_planner.py
@@ -1,0 +1,68 @@
+from __future__ import annotations
+
+from typing import List, Optional
+from pathlib import Path
+
+from pydantic import BaseModel
+from agents import Agent, Runner
+from agents.mcp import MCPServerSse
+
+
+OFFICE_SEARCH_PROMPT_PATH = (
+    Path(__file__).resolve().parent.parent.parent.parent
+    / "prompts"
+    / "off_ice_search_prompt.yaml"
+)
+
+
+def _load_prompt() -> str:
+    with open(OFFICE_SEARCH_PROMPT_PATH, "r", encoding="utf-8") as f:
+        return "".join(f.readlines()[1:]).lstrip()
+
+
+class OffIceSearchResult(BaseModel):
+    title: str
+    category: str
+    focus_area: str
+    teaching_complexity: str
+    progression_stage: str
+    description: str
+    equipment_needed: Optional[str] = None
+    source_pages: str
+
+
+class OffIceSearchResults(BaseModel):
+    items: List[OffIceSearchResult]
+
+
+office_agent = Agent(
+    name="OffIceSearchAgent",
+    instructions=_load_prompt(),
+    handoffs=[],
+    output_type=OffIceSearchResults,
+    mcp_servers=[MCPServerSse(name="Thunder MCP Server", params={"url": "http://localhost:8000/sse"})],
+    model="gpt-4o",
+)
+
+
+class OffIcePlannerManager:
+    def __init__(self, mcp_server=None, model=None) -> None:
+        if model:
+            office_agent.model = model
+        if mcp_server:
+            office_agent.mcp_servers = [mcp_server]
+
+    async def run(self, input_text: str, trace_id: str | None = None) -> OffIceSearchResults:
+        if trace_id:
+            print(f"\n🔗 View trace: https://platform.openai.com/traces/trace?trace_id={trace_id}\n")
+
+        result = await Runner.run(office_agent, input_text)
+        output = result.final_output_as(OffIceSearchResults)
+
+        # Safeguards: limit results and validate required fields
+        output.items = output.items[:10]
+        for item in output.items:
+            if not (item.title and item.description and item.category and item.focus_area):
+                raise ValueError("Incomplete off-ice search result")
+        return output
+

--- a/app/client/off_ice_main.py
+++ b/app/client/off_ice_main.py
@@ -1,0 +1,54 @@
+import argparse
+import asyncio
+import shutil
+import subprocess
+import time
+from pathlib import Path
+from typing import Any
+
+from agents import gen_trace_id, trace
+from agents.mcp import MCPServerSse
+from app.client.agent.off_ice_planner import OffIcePlannerManager, OffIceSearchResults
+
+
+async def run_pipeline(input_text: str) -> OffIceSearchResults:
+    async with MCPServerSse(
+        name="Thunder MCP Server",
+        params={"url": "http://localhost:8000/sse"},
+    ) as mcp_server:
+        trace_id = gen_trace_id()
+        with trace("off_ice_search", trace_id=trace_id):
+            mgr = OffIcePlannerManager(mcp_server)
+            result = await mgr.run(input_text, trace_id=trace_id)
+            for item in result.items:
+                print(f"- {item.title} ({item.category}) -> pages {item.source_pages}")
+            return result
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--input", type=str, required=True, help="Query text for off-ice search")
+    args = parser.parse_args()
+
+    if not shutil.which("uv"):
+        raise RuntimeError("Missing `uv`. Install it from https://docs.astral.sh/uv/")
+
+    print("🚀 Launching Thunder MCP SSE server at http://localhost:8000/sse ...")
+
+    server_path = Path(__file__).resolve().parent.parent / "mcp_server" / "off_ice_mcp_server.py"
+    process: subprocess.Popen[Any] | None = subprocess.Popen(["uv", "run", str(server_path)])
+    time.sleep(3)
+
+    print("✅ Server started. Connecting agent...\n")
+
+    try:
+        asyncio.run(run_pipeline(args.input))
+    finally:
+        if process:
+            print("\n🛑 Shutting down server...")
+            process.terminate()
+
+
+if __name__ == "__main__":
+    main()
+

--- a/app/mcp_server/off_ice_mcp_server.py
+++ b/app/mcp_server/off_ice_mcp_server.py
@@ -1,0 +1,76 @@
+from __future__ import annotations
+
+"""MCP server exposing off-ice training search tools."""
+
+from typing import List, Optional, TypedDict
+
+from mcp.server.fastmcp import FastMCP
+
+from .chroma_utils import get_chroma_collection
+
+mcp = FastMCP("Thunder Off-Ice KB")
+collection = get_chroma_collection()
+
+
+class OffIceResult(TypedDict):
+    title: str
+    category: str
+    focus_area: str
+    teaching_complexity: str
+    progression_stage: str
+    description: str
+    equipment_needed: Optional[str]
+    source_pages: str
+
+
+@mcp.resource("schema://off_ice", title="Off-Ice Entry Schema")
+def get_office_schema() -> str:
+    return """{
+  \"title\": \"string\",
+  \"category\": \"string\",
+  \"focus_area\": \"string\",
+  \"teaching_complexity\": \"string\",
+  \"progression_stage\": \"string\",
+  \"description\": \"string\",
+  \"equipment_needed\": \"string | null\",
+  \"source_pages\": \"string\"
+}"""
+
+
+def _parse_description(doc: str) -> str:
+    for line in doc.splitlines():
+        if line.lower().startswith("description:"):
+            return line.split(":", 1)[1].strip()
+    return ""
+
+
+@mcp.tool("semantic_search_office")
+def semantic_search_office(query: str, n_results: int = 5) -> List[OffIceResult]:
+    """Semantic search over off-ice training entries."""
+    results = collection.query(
+        query_texts=[query],
+        n_results=n_results,
+        where={"source": "off_ice_manual_hockey_canada_level1"},
+    )
+    docs = results.get("documents", [[]])[0]
+    metas = results.get("metadatas", [[]])[0]
+
+    entries: List[OffIceResult] = []
+    for doc, meta in zip(docs, metas):
+        entries.append(
+            {
+                "title": meta.get("title", ""),
+                "category": meta.get("category", ""),
+                "focus_area": meta.get("focus_area", ""),
+                "teaching_complexity": meta.get("teaching_complexity", ""),
+                "progression_stage": meta.get("progression_stage", ""),
+                "description": _parse_description(doc),
+                "equipment_needed": meta.get("equipment_needed") or None,
+                "source_pages": meta.get("source_pages", ""),
+            }
+        )
+    return entries
+
+
+if __name__ == "__main__":
+    mcp.run(transport="sse")

--- a/prompts/off_ice_search_prompt.yaml
+++ b/prompts/off_ice_search_prompt.yaml
@@ -1,0 +1,2 @@
+prompt: |
+  You are an off-ice training assistant. You help users find relevant off-ice exercises and routines to meet their goal. Based on the user's input, return a list of relevant off-ice items with a short description of each.


### PR DESCRIPTION
## Summary
- implement Off-Ice MCP server for querying the off‑ice manual index
- create OffIceSearchAgent and planner manager
- add CLI entry point `off_ice_main.py`
- new prompt file for off‑ice search instructions

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `poetry run python app/client/off_ice_main.py --input "core strength and agility"` *(fails: ModuleNotFoundError)*

------
https://chatgpt.com/codex/tasks/task_e_6875a123bf848326968df894227c5be0