### PR TITLE
Add off‑ice workout planner system

### DIFF
--- a/app/client/agent/off_ice_workout_planner.py
+++ b/app/client/agent/off_ice_workout_planner.py
@@ -1,0 +1,192 @@
+from __future__ import annotations
+
+"""Multi-agent orchestration for generating an off-ice workout plan."""
+
+from pathlib import Path
+from typing import List
+import hashlib
+from pydantic import BaseModel
+
+from agents import Agent, Runner
+from agents.mcp import MCPServerSse
+from .off_ice_planner import office_agent, OffIceSearchResults
+
+PROMPTS_DIR = Path(__file__).resolve().parent.parent.parent.parent / "prompts"
+
+
+def _load_prompt(name: str) -> str:
+    path = PROMPTS_DIR / name
+    with open(path, "r", encoding="utf-8") as f:
+        return "".join(f.readlines()[1:]).lstrip()
+
+
+# === Step 1: Input Structurer ===
+class StructuredInput(BaseModel):
+    age_group: str
+    sport: str
+    start_date: str
+    end_date: str
+    frequency: str
+    goals: List[str]
+
+
+input_structurer_agent = Agent(
+    name="WorkoutInputStructurer",
+    instructions=_load_prompt("off_ice_workout_input_prompt.yaml"),
+    output_type=StructuredInput,
+    mcp_servers=[MCPServerSse(name="Thunder MCP Server", params={"url": "http://localhost:8000/sse"})],
+    model="gpt-4o",
+)
+
+# === Step 2: Plan Outliner ===
+class PlanOutline(BaseModel):
+    outline: str
+
+
+plan_outliner_agent = Agent(
+    name="WorkoutPlanOutliner",
+    instructions=_load_prompt("off_ice_workout_outline_prompt.yaml"),
+    output_type=PlanOutline,
+    model="gpt-4o",
+)
+
+# === Step 3: Research Planner ===
+class ResearchTopics(BaseModel):
+    topics: List[str]
+
+
+research_planner_agent = Agent(
+    name="WorkoutResearchPlanner",
+    instructions=_load_prompt("off_ice_workout_research_prompt.yaml"),
+    output_type=ResearchTopics,
+    model="gpt-4o",
+)
+
+# === Step 4: Web Researcher ===
+class ResearchSummary(BaseModel):
+    bullets: List[str]
+
+
+from agents import WebSearchTool
+
+web_researcher_agent = Agent(
+    name="WorkoutWebResearcher",
+    instructions=_load_prompt("off_ice_workout_web_prompt.yaml"),
+    output_type=ResearchSummary,
+    tools=[WebSearchTool()],
+    model="gpt-4o",
+)
+
+# === Step 6: Synthesizer (after retrieval) ===
+class DraftPlan(BaseModel):
+    draft: str
+
+
+synthesizer_agent = Agent(
+    name="WorkoutSynthesizer",
+    instructions=_load_prompt("off_ice_workout_synth_prompt.yaml"),
+    output_type=DraftPlan,
+    model="gpt-4o",
+)
+
+# === Step 7: Polisher ===
+class FinalPlan(BaseModel):
+    final: str
+
+
+polisher_agent = Agent(
+    name="WorkoutPolisher",
+    instructions=_load_prompt("off_ice_workout_polish_prompt.yaml"),
+    output_type=FinalPlan,
+    model="gpt-4o",
+)
+
+
+class WorkoutPlanOutput(BaseModel):
+    file_path: str
+    plan: str
+
+
+class OffIceWorkoutPlannerManager:
+    def __init__(self, mcp_server=None, model=None) -> None:
+        agents = [
+            input_structurer_agent,
+            plan_outliner_agent,
+            research_planner_agent,
+            web_researcher_agent,
+            synthesizer_agent,
+            polisher_agent,
+            office_agent,
+        ]
+        if model:
+            for a in agents:
+                a.model = model
+        if mcp_server:
+            for a in agents:
+                a.mcp_servers = [mcp_server]
+
+    async def run(self, input_text: str, trace_id: str | None = None) -> WorkoutPlanOutput:
+        if trace_id:
+            print(f"\n🔗 View trace: https://platform.openai.com/traces/trace?trace_id={trace_id}\n")
+
+        # Step 1
+        res = await Runner.run(input_structurer_agent, input_text)
+        structured = res.final_output_as(StructuredInput)
+
+        # Step 2
+        res = await Runner.run(plan_outliner_agent, structured.model_dump_json(indent=2))
+        outline = res.final_output_as(PlanOutline)
+
+        # Step 3
+        topics_input = (
+            f"Input:\n{structured.model_dump_json(indent=2)}\n\nOutline:\n{outline.outline}"
+        )
+        res = await Runner.run(research_planner_agent, topics_input)
+        topics = res.final_output_as(ResearchTopics)
+
+        # Step 4
+        res = await Runner.run(web_researcher_agent, "\n".join(topics.topics))
+        research = res.final_output_as(ResearchSummary)
+
+        # Step 5: Chroma retrieval using existing off-ice search agent
+        search_query = "; ".join(structured.goals) + " " + outline.outline
+        res = await Runner.run(office_agent, search_query)
+        chroma_results = res.final_output_as(OffIceSearchResults)
+
+        # Step 6
+        synth_input = (
+            f"STRUCTURED:\n{structured.model_dump_json(indent=2)}\n\n"
+            f"OUTLINE:\n{outline.outline}\n\n"
+            f"RESEARCH:\n{research.model_dump_json(indent=2)}\n\n"
+            f"EXERCISES:\n{chroma_results.model_dump_json(indent=2)}"
+        )
+        res = await Runner.run(synthesizer_agent, synth_input)
+        draft = res.final_output_as(DraftPlan)
+
+        # Step 7
+        res = await Runner.run(polisher_agent, draft.draft)
+        final_plan = res.final_output_as(FinalPlan)
+
+        # Step 8: Save markdown
+        file_path = self._save_markdown(final_plan.final, structured)
+        print(f"✅ Plan saved to {file_path}")
+
+        return WorkoutPlanOutput(file_path=file_path, plan=final_plan.final)
+
+    def _save_markdown(self, text: str, meta: StructuredInput) -> str:
+        base = Path(__file__).resolve().parent.parent.parent.parent / "data" / "generated"
+        base.mkdir(parents=True, exist_ok=True)
+        digest = hashlib.sha1(text.encode("utf-8")).hexdigest()[:8]
+        path = base / f"workout_plan_{digest}.md"
+        frontmatter = (
+            "---\n"
+            f"title: Off-Ice Workout Plan\n"
+            f"sport: {meta.sport}\n"
+            f"age_group: {meta.age_group}\n"
+            f"date_range: {meta.start_date} to {meta.end_date}\n"
+            f"frequency: {meta.frequency}\n"
+            f"goals: {'; '.join(meta.goals)}\n"
+            "---\n\n"
+        )
+        path.write_text(frontmatter + text, encoding="utf-8")
+        return str(path)

--- a/app/client/off_ice_workout_main.py
+++ b/app/client/off_ice_workout_main.py
@@ -1,0 +1,52 @@
+import argparse
+import asyncio
+import shutil
+import subprocess
+import time
+from pathlib import Path
+from typing import Any
+
+from agents import gen_trace_id, trace
+from agents.mcp import MCPServerSse
+from app.client.agent.off_ice_workout_planner import OffIceWorkoutPlannerManager, WorkoutPlanOutput
+
+
+async def run_pipeline(input_text: str) -> WorkoutPlanOutput:
+    async with MCPServerSse(
+        name="Thunder MCP Server",
+        params={"url": "http://localhost:8000/sse"},
+    ) as mcp_server:
+        trace_id = gen_trace_id()
+        with trace("off_ice_workout", trace_id=trace_id):
+            mgr = OffIceWorkoutPlannerManager(mcp_server)
+            result = await mgr.run(input_text, trace_id=trace_id)
+            return result
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--input", type=str, required=True, help="Workout plan request")
+    args = parser.parse_args()
+
+    if not shutil.which("uv"):
+        raise RuntimeError("Missing `uv`. Install it from https://docs.astral.sh/uv/")
+
+    print("🚀 Launching Thunder MCP SSE server at http://localhost:8000/sse ...")
+
+    server_path = Path(__file__).resolve().parent.parent / "mcp_server" / "off_ice_mcp_server.py"
+    process: subprocess.Popen[Any] | None = subprocess.Popen(["uv", "run", str(server_path)])
+    time.sleep(3)
+
+    print("✅ Server started. Connecting agent...\n")
+
+    try:
+        result = asyncio.run(run_pipeline(args.input))
+        print(f"Plan saved to {result.file_path}")
+    finally:
+        if process:
+            print("\n🛑 Shutting down server...")
+            process.terminate()
+
+
+if __name__ == "__main__":
+    main()

--- a/app/mcp_server/off_ice_mcp_server.py
+++ b/app/mcp_server/off_ice_mcp_server.py
@@ -7,9 +7,11 @@ from typing import List, Optional, TypedDict
 from mcp.server.fastmcp import FastMCP
 
 from .chroma_utils import get_chroma_collection
+from .tools import datetime_tools
 
 mcp = FastMCP("Thunder Off-Ice KB")
 collection = get_chroma_collection()
+mcp.mount(datetime_tools.mcp)
 
 
 class OffIceResult(TypedDict):

--- a/app/mcp_server/tools/datetime_tools.py
+++ b/app/mcp_server/tools/datetime_tools.py
@@ -1,0 +1,16 @@
+from __future__ import annotations
+
+"""Simple date/time utility tools for MCP."""
+
+from datetime import datetime, timezone
+from fastmcp import FastMCP
+
+mcp = FastMCP("Datetime Tools")
+
+@mcp.tool("get_current_date")
+def get_current_date(fmt: str = "%Y-%m-%d") -> str:
+    """Return the current UTC date formatted as a string."""
+    return datetime.now(timezone.utc).strftime(fmt)
+
+if __name__ == "__main__":
+    mcp.run(transport="sse")

--- a/prompts/off_ice_workout_input_prompt.yaml
+++ b/prompts/off_ice_workout_input_prompt.yaml
@@ -1,0 +1,10 @@
+prompt: |
+  You are an intake agent that prepares workout plan requests.
+  Parse the user's text and return strict JSON with these keys:
+    - age_group
+    - sport
+    - start_date (YYYY-MM-DD)
+    - end_date (YYYY-MM-DD)
+    - frequency
+    - goals (list of words)
+  If dates are missing, call `get_current_date` to choose a reasonable start date.

--- a/prompts/off_ice_workout_outline_prompt.yaml
+++ b/prompts/off_ice_workout_outline_prompt.yaml
@@ -1,0 +1,4 @@
+prompt: |
+  You are an off-ice program architect.
+  Using the structured input below, create a concise session-by-session outline highlighting weekly focus areas.
+  Mention expectations for coaches, parents, and players.

--- a/prompts/off_ice_workout_polish_prompt.yaml
+++ b/prompts/off_ice_workout_polish_prompt.yaml
@@ -1,0 +1,3 @@
+prompt: |
+  Polish the draft workout plan so it is easy to read for players, parents, and coaches.
+  Maintain the outline structure and keep language encouraging and age-appropriate.

--- a/prompts/off_ice_workout_research_prompt.yaml
+++ b/prompts/off_ice_workout_research_prompt.yaml
@@ -1,0 +1,3 @@
+prompt: |
+  Based on the structured input and outline, list 5-10 topics to research in order to craft the workouts.
+  Return the topics as a bullet list.

--- a/prompts/off_ice_workout_synth_prompt.yaml
+++ b/prompts/off_ice_workout_synth_prompt.yaml
@@ -1,0 +1,3 @@
+prompt: |
+  Combine the outline, research insights, and exercise search results into a draft workout plan.
+  Organize the plan chronologically and keep it concise.

--- a/prompts/off_ice_workout_web_prompt.yaml
+++ b/prompts/off_ice_workout_web_prompt.yaml
@@ -1,0 +1,3 @@
+prompt: |
+  Use web search to gather short insights for each research topic provided.
+  Summarize each topic in 1-2 sentences.


### PR DESCRIPTION
## Summary
- implement multi-agent off-ice workout planner
- add CLI launcher for planner
- create datetime tool and mount it to Off-Ice MCP server
- add YAML prompts for each planner step

## Testing
- `python -m py_compile app/client/agent/off_ice_workout_planner.py app/client/off_ice_workout_main.py app/mcp_server/tools/datetime_tools.py app/mcp_server/off_ice_mcp_server.py`

------
https://chatgpt.com/codex/tasks/task_e_6875a7752de883268fc8ae4e5c02d311