### PR TITLE
Enhance workout planner output images

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,5 @@ chroma_db/
 *.lock
 *.mp4
 *.mp3
+data/generated/images/*
+!data/generated/images/.gitkeep


### PR DESCRIPTION
## Summary
- include image metadata in `FinalPlan`
- save generated images to disk and embed them in markdown
- use `previous_response_id` to thread agent responses
- ignore generated images

## Testing
- `python -m py_compile app/client/agent/off_ice_workout_planner.py app/client/off_ice_workout_main.py`
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_687665c846308326829c5902e5afec2b