### PR TITLE
Update off-ice workout planner flow

### DIFF
--- a/prompts/off_ice_workout_outline_prompt.yaml
+++ b/prompts/off_ice_workout_outline_prompt.yaml
@@ -1,5 +1,5 @@
 prompt: |
-  You are an off-ice program architect.
-  Using the structured input below, design a high-level seasonal dryland training overview instead of a week-by-week schedule.
-  Summarize overall goals, session structure, progression strategy, and how the specified location and amenities will be used.
-  Include expectations and engagement ideas for coaches, parents, and players.
+  You are a dryland session architect.
+  From the structured input, outline the core blocks of a typical workout (warm-up, agility, strength, etc.).
+  When unsure about the best order, call `get_recommended_sequence` to ground the agenda in the off-ice knowledge base.
+  Return the agenda in short Markdown bullet form so later agents can build on it.

--- a/prompts/off_ice_workout_progression_prompt.yaml
+++ b/prompts/off_ice_workout_progression_prompt.yaml
@@ -1,0 +1,4 @@
+prompt: |
+  Craft a short progression overview for the season.
+  Use `summarize_office_by_category` to recall key objectives for each session category.
+  For each major focus area, call `get_progressions_for_focus_area` and weave the insights into concise markdown.

--- a/prompts/off_ice_workout_synth_prompt.yaml
+++ b/prompts/off_ice_workout_synth_prompt.yaml
@@ -1,5 +1,4 @@
 prompt: |
-  Combine the outline, research insights, and exercise search results into a draft workout plan.
-  Provide a holistic seasonal overview instead of a week-by-week list.
-  Explain how the location and amenities shape each session and the progression strategy.
-  Keep it concise and age-appropriate.
+  Write the full dryland workout plan using the session structure, progression notes and research snippets.
+  Keep the tone friendly and concise so it is easy for kids, parents and coaches to follow.
+  Format the output in Markdown with clear headings and bullet points.


### PR DESCRIPTION
## Summary
- refactor workout planner agent to use new dryland structure and progression stages
- add CLI option to generate images
- include new prompts for structure, progression and synthesis

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_6876af5947508326bc3e2676409b36c1