### PR TITLE
Fix off-ice timeout issues

### DIFF
--- a/app/client/agent/off_ice_planner.py
+++ b/app/client/agent/off_ice_planner.py
@@ -40,7 +40,7 @@ office_agent = Agent(
     instructions=_load_prompt(),
     handoffs=[],
     output_type=OffIceSearchResults,
-    mcp_servers=[MCPServerSse(name="Off-Ice KB MCP Server", params={"url": "http://localhost:8000/sse"})],
+    mcp_servers=[MCPServerSse(name="Off-Ice KB MCP Server", params={"url": "http://localhost:8000/sse", "timeout": 30})],
     model="gpt-4o",
 )
 

--- a/app/client/agent/off_ice_workout_planner.py
+++ b/app/client/agent/off_ice_workout_planner.py
@@ -62,7 +62,7 @@ dryland_structure_agent = Agent(
     name="DrylandStructureAgent",
     instructions=_load_prompt("off_ice_workout_outline_prompt.yaml"),
     output_type=DrylandStructure,
-    mcp_servers=[MCPServerSse(name="Off-Ice KB MCP Server", params={"url": "http://localhost:8000/sse"})],
+    mcp_servers=[MCPServerSse(name="Off-Ice KB MCP Server", params={"url": "http://localhost:8000/sse", "timeout": 30})],
     model="gpt-4o",
 )
 
@@ -76,7 +76,7 @@ dryland_progression_agent = Agent(
     name="DrylandProgressionAgent",
     instructions=_load_prompt("off_ice_workout_progression_prompt.yaml"),
     output_type=DrylandProgression,
-    mcp_servers=[MCPServerSse(name="Off-Ice KB MCP Server", params={"url": "http://localhost:8000/sse"})],
+    mcp_servers=[MCPServerSse(name="Off-Ice KB MCP Server", params={"url": "http://localhost:8000/sse", "timeout": 30})],
     model="gpt-4o",
 )
 

--- a/app/client/off_ice_main.py
+++ b/app/client/off_ice_main.py
@@ -14,7 +14,7 @@ from app.client.agent.off_ice_planner import OffIcePlannerManager, OffIceSearchR
 async def run_pipeline(input_text: str) -> OffIceSearchResults:
     async with MCPServerSse(
         name="Off-Ice KB MCP Server",
-        params={"url": "http://localhost:8000/sse"},
+        params={"url": "http://localhost:8000/sse", "timeout": 30},
     ) as mcp_server:
         trace_id = gen_trace_id()
         with trace("off_ice_search", trace_id=trace_id):

--- a/app/client/off_ice_workout_main.py
+++ b/app/client/off_ice_workout_main.py
@@ -14,7 +14,7 @@ from app.client.agent.off_ice_workout_planner import OffIceWorkoutPlannerManager
 async def run_pipeline(input_text: str, generate_images: bool = False) -> WorkoutPlanOutput:
     async with MCPServerSse(
         name="Off-Ice KB MCP Server",
-        params={"url": "http://localhost:8000/sse"},
+        params={"url": "http://localhost:8000/sse", "timeout": 30},
     ) as mcp_server:
         trace_id = gen_trace_id()
         with trace("off_ice_workout", trace_id=trace_id):

--- a/app/mcp_server/off_ice_mcp_server.py
+++ b/app/mcp_server/off_ice_mcp_server.py
@@ -138,7 +138,7 @@ def summarize_office_by_category(n_per_category: int = 5) -> List[CategorySummar
     return summaries
 
 
-@mcp.tool("get_recommended_sequence")
+@mcp.tool("get_recommended_sequence", timeout=30)
 def get_recommended_sequence(prompt: str) -> List[SequencePhase]:
     """Generate a structured session sequence from a natural language prompt."""
     results = collection.query(


### PR DESCRIPTION
## Summary
- extend `get_recommended_sequence` timeout to 30s
- configure all off-ice agents and CLIs with 30s MCP server timeout

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6876b95f762083268bf99af853d0bb60