### PR TITLE
Fix MCP tool timeout and client config

### DIFF
--- a/app/mcp_server/off_ice_mcp_server.py
+++ b/app/mcp_server/off_ice_mcp_server.py
@@ -138,7 +138,7 @@ def summarize_office_by_category(n_per_category: int = 5) -> List[CategorySummar
     return summaries
 
 
-@mcp.tool("get_recommended_sequence", timeout=30)
+@mcp.tool("get_recommended_sequence")
 def get_recommended_sequence(prompt: str) -> List[SequencePhase]:
     """Generate a structured session sequence from a natural language prompt."""
     results = collection.query(


### PR DESCRIPTION
## Summary
- remove unsupported `timeout` param from `@mcp.tool` decorator
- ensure workout planner client connects to SSE server with timeout parameter

## Testing
- `python -m py_compile app/mcp_server/off_ice_mcp_server.py app/client/agent/off_ice_workout_planner.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6876eb2f34288326ac84f8a31a5eb486