### PR TITLE
Add dryland video summary tools

### DIFF
--- a/client/off_ice/dryland_video_summary_agent.py
+++ b/client/off_ice/dryland_video_summary_agent.py
@@ -1,0 +1,64 @@
+from __future__ import annotations
+
+"""Agent to search and summarize dryland training video clips."""
+
+import argparse
+import asyncio
+import hashlib
+import json
+from pathlib import Path
+from typing import Optional
+
+from pydantic import BaseModel
+from agents import Agent, Runner
+from agents.mcp import MCPServerSse
+
+PROMPTS_DIR = Path(__file__).resolve().parents[2] / "prompts" / "off_ice"
+
+
+def _load_prompt(name: str) -> str:
+    path = PROMPTS_DIR / name
+    with open(path, "r", encoding="utf-8") as f:
+        return "".join(f.readlines()[1:]).lstrip()
+
+
+class VideoSummary(BaseModel):
+    markdown: str
+
+
+dryland_video_summary_agent = Agent(
+    name="DrylandVideoSummary",
+    instructions=_load_prompt("video_summary_prompt.yaml"),
+    output_type=VideoSummary,
+    mcp_servers=[MCPServerSse(name="Off-Ice KB MCP Server", params={"url": "http://localhost:8000/sse", "timeout": 30})],
+    model="gpt-4o",
+)
+
+
+async def run_agent(query: Optional[str] = None, title: Optional[str] = None) -> VideoSummary:
+    payload = json.dumps({"query": query, "title": title})
+    res = await Runner.run(dryland_video_summary_agent, payload, max_turns=10)
+    return res.final_output_as(VideoSummary)
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--query", type=str, help="Search query")
+    parser.add_argument("--title", type=str, help="Video title")
+    args = parser.parse_args()
+
+    if not args.query and not args.title:
+        parser.error("Provide --query or --title")
+
+    summary = asyncio.run(run_agent(args.query, args.title))
+
+    base = Path(__file__).resolve().parents[2] / "data" / "generated"
+    base.mkdir(parents=True, exist_ok=True)
+    digest = hashlib.sha1((args.query or args.title).encode("utf-8")).hexdigest()[:8]
+    out_path = base / f"dryland_video_summary_{digest}.md"
+    out_path.write_text(summary.markdown, encoding="utf-8")
+    print(f"✅ Summary saved to {out_path}")
+
+
+if __name__ == "__main__":
+    main()

--- a/client/off_ice/off_ice_workout_main.py
+++ b/client/off_ice/off_ice_workout_main.py
@@ -11,7 +11,7 @@ from agents.mcp import MCPServerSse
 from .off_ice_workout_planner import OffIceWorkoutPlannerManager, WorkoutPlanOutput
 
 
-async def run_pipeline(input_text: str, generate_images: bool = False) -> WorkoutPlanOutput:
+async def run_pipeline(input_text: str, generate_images: bool = False, include_video: bool = False) -> WorkoutPlanOutput:
     async with MCPServerSse(
         name="Off-Ice KB MCP Server",
         params={"url": "http://localhost:8000/sse", "timeout": 30},
@@ -19,7 +19,7 @@ async def run_pipeline(input_text: str, generate_images: bool = False) -> Workou
         trace_id = gen_trace_id()
         with trace("off_ice_workout", trace_id=trace_id):
             mgr = OffIceWorkoutPlannerManager(mcp_server, generate_images=generate_images)
-            result = await mgr.run(input_text, trace_id=trace_id)
+            result = await mgr.run(input_text, include_video=include_video, trace_id=trace_id)
             return result
 
 
@@ -27,6 +27,7 @@ def main() -> None:
     parser = argparse.ArgumentParser()
     parser.add_argument("--input", type=str, required=True, help="Workout plan request")
     parser.add_argument("--generate-images", action="store_true", help="Include generated visuals")
+    parser.add_argument("--include-video", action="store_true", help="Include video summary")
     args = parser.parse_args()
 
     if not shutil.which("uv"):
@@ -41,7 +42,7 @@ def main() -> None:
     print("✅ Server started. Connecting agent...\n")
 
     try:
-        result = asyncio.run(run_pipeline(args.input, generate_images=args.generate_images))
+        result = asyncio.run(run_pipeline(args.input, generate_images=args.generate_images, include_video=args.include_video))
         print(f"Plan saved to {result.file_path}")
     finally:
         if process:

--- a/prompts/off_ice/video_summary_prompt.yaml
+++ b/prompts/off_ice/video_summary_prompt.yaml
@@ -1,0 +1,6 @@
+prompt: |
+  You are a video librarian for dryland training clips.
+  If provided a "query", call `search_dryland_video_titles` to find matching videos.
+  If a "title" is given or once you've chosen a title, call `get_video_clips_by_title` to retrieve all segments.
+  Summarize the clips with coaching tips, complexity or age focus, and include links in the form `https://www.youtube.com/watch?v={video_id}&t={start_time}s`.
+  Return the final write-up in Markdown.


### PR DESCRIPTION
## Summary
- add Chroma-backed video tools to off_ice MCP server
- create `dryland_video_summary_agent` for summarizing clips
- integrate optional video summaries into workout planner
- update writer agent and CLI drivers

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687792041e448326babc87615fd8666e