### PR TITLE
Add dryland planner and session agents

### DIFF
--- a/client/off_ice/dryland_context_tools.py
+++ b/client/off_ice/dryland_context_tools.py
@@ -1,0 +1,29 @@
+from __future__ import annotations
+
+from typing import Any
+
+from agents import function_tool, RunContextWrapper
+
+from models.dryland_models import DrylandContext
+
+
+@function_tool
+def set_dryland_context_param(
+    ctx: RunContextWrapper[DrylandContext], key: str, value: Any
+) -> str:
+    """Update a value in the dryland session context."""
+    if ctx.context is None:
+        ctx.context = DrylandContext()
+    if not hasattr(ctx.context, key):
+        raise ValueError(f"Unknown context key: {key}")
+    if key == "equipment":
+        if isinstance(value, str):
+            ctx.context.equipment = [v.strip() for v in value.split(',') if v.strip()]
+        elif isinstance(value, list):
+            ctx.context.equipment = [str(v) for v in value]
+        else:
+            raise ValueError("equipment must be a string or list")
+    else:
+        setattr(ctx.context, key, value)
+    return f"{key} updated"
+

--- a/client/off_ice/dryland_loop_agent.py
+++ b/client/off_ice/dryland_loop_agent.py
@@ -1,0 +1,68 @@
+from __future__ import annotations
+
+import argparse
+import asyncio
+import shutil
+import subprocess
+import time
+from datetime import date
+from pathlib import Path
+from typing import Any, Optional
+
+from agents import gen_trace_id, trace
+from agents.mcp import MCPServerSse
+
+from models.dryland_models import DrylandContext
+from .dryland_planner_agent import run_agent as run_plan_agent
+from .dryland_session_agent import run_agent as run_session_agent
+
+
+async def run_pipeline(session_date: Optional[date] = None) -> None:
+    async with MCPServerSse(
+        name="Off-Ice KB MCP Server",
+        params={"url": "http://localhost:8000/sse", "timeout": 30},
+    ) as mcp_server:
+        ctx = DrylandContext()
+        trace_id = gen_trace_id()
+        with trace("dryland_plan", trace_id=trace_id):
+            plan = await run_plan_agent(ctx)
+            ctx.plan = plan
+        if session_date:
+            with trace("dryland_session", trace_id=trace_id):
+                session = await run_session_agent(session_date, ctx)
+                out_dir = Path("data/generated")
+                out_dir.mkdir(parents=True, exist_ok=True)
+                (out_dir / f"session_{session_date}.json").write_text(
+                    session.model_dump_json(indent=2), encoding="utf-8"
+                )
+                print(f"✅ Session for {session_date} saved")
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--date", type=str, help="Generate session for this date (YYYY-MM-DD)")
+    args = parser.parse_args()
+
+    if not shutil.which("uv"):
+        raise RuntimeError("Missing `uv`. Install it from https://docs.astral.sh/uv/")
+
+    print("🚀 Launching Thunder MCP SSE server at http://localhost:8000/sse ...")
+
+    server_path = Path(__file__).resolve().parents[1] / "mcp_server" / "off_ice" / "off_ice_mcp_server.py"
+    process: subprocess.Popen[Any] | None = subprocess.Popen(["uv", "run", str(server_path)])
+    time.sleep(3)
+
+    print("✅ Server started. Connecting agent...\n")
+
+    try:
+        ses_date = date.fromisoformat(args.date) if args.date else None
+        asyncio.run(run_pipeline(ses_date))
+    finally:
+        if process:
+            print("\n🛑 Shutting down server...")
+            process.terminate()
+
+
+if __name__ == "__main__":
+    main()
+

--- a/client/off_ice/dryland_planner_agent.py
+++ b/client/off_ice/dryland_planner_agent.py
@@ -1,0 +1,56 @@
+from __future__ import annotations
+
+import argparse
+import asyncio
+from pathlib import Path
+from typing import Optional
+
+from agents import Agent, Runner, WebSearchTool
+from agents.mcp import MCPServerSse
+
+from models.dryland_models import DrylandContext, DrylandPlanOutput
+from .dryland_context_tools import set_dryland_context_param
+
+PROMPTS_DIR = Path(__file__).resolve().parents[2] / "prompts" / "off_ice"
+
+
+def _load_prompt() -> str:
+    path = PROMPTS_DIR / "dryland_plan_prompt.yaml"
+    with open(path, "r", encoding="utf-8") as f:
+        return "".join(f.readlines()[1:]).lstrip()
+
+
+dryland_planner_agent = Agent(
+    name="DrylandPlannerAgent",
+    instructions=_load_prompt(),
+    output_type=DrylandPlanOutput,
+    tools=[set_dryland_context_param, WebSearchTool()],
+    mcp_servers=[MCPServerSse(name="Off-Ice KB MCP Server", params={"url": "http://localhost:8000/sse", "timeout": 30})],
+    model="gpt-4o",
+)
+
+
+async def run_agent(context: DrylandContext, *, max_turns: int = 20) -> DrylandPlanOutput:
+    res = await Runner.run(dryland_planner_agent, "", context=context, max_turns=max_turns)
+    plan = res.final_output_as(DrylandPlanOutput)
+    context.plan = plan
+    return plan
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--context", type=Path, help="Optional context JSON")
+    parser.add_argument("--output", type=Path, default=Path("dryland_plan.json"))
+    args = parser.parse_args()
+
+    ctx = DrylandContext()
+    if args.context and args.context.exists():
+        ctx = DrylandContext.model_validate_json(args.context.read_text())
+
+    plan = asyncio.run(run_agent(ctx))
+    args.output.write_text(plan.model_dump_json(indent=2), encoding="utf-8")
+    print(f"✅ Plan saved to {args.output}")
+
+
+if __name__ == "__main__":
+    main()

--- a/client/off_ice/dryland_session_agent.py
+++ b/client/off_ice/dryland_session_agent.py
@@ -1,0 +1,53 @@
+from __future__ import annotations
+
+import argparse
+import asyncio
+from datetime import date
+from pathlib import Path
+
+from agents import Agent, Runner, WebSearchTool
+from agents.mcp import MCPServerSse
+
+from models.dryland_models import DrylandContext, DrylandSessionOutput
+from .dryland_context_tools import set_dryland_context_param
+
+PROMPTS_DIR = Path(__file__).resolve().parents[2] / "prompts" / "off_ice"
+
+
+def _load_prompt() -> str:
+    path = PROMPTS_DIR / "dryland_session_prompt.yaml"
+    with open(path, "r", encoding="utf-8") as f:
+        return "".join(f.readlines()[1:]).lstrip()
+
+
+dryland_session_agent = Agent(
+    name="DrylandSessionAgent",
+    instructions=_load_prompt(),
+    output_type=DrylandSessionOutput,
+    tools=[set_dryland_context_param, WebSearchTool()],
+    mcp_servers=[MCPServerSse(name="Off-Ice KB MCP Server", params={"url": "http://localhost:8000/sse", "timeout": 30})],
+    model="gpt-4o",
+)
+
+
+async def run_agent(session_date: date, context: DrylandContext, *, max_turns: int = 20) -> DrylandSessionOutput:
+    res = await Runner.run(dryland_session_agent, session_date.isoformat(), context=context, max_turns=max_turns)
+    return res.final_output_as(DrylandSessionOutput)
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--date", type=str, required=True)
+    parser.add_argument("--context", type=Path, required=True)
+    parser.add_argument("--output", type=Path, default=Path("dryland_session.json"))
+    args = parser.parse_args()
+
+    ctx = DrylandContext.model_validate_json(args.context.read_text())
+    session = asyncio.run(run_agent(date.fromisoformat(args.date), ctx))
+    args.output.write_text(session.model_dump_json(indent=2), encoding="utf-8")
+    print(f"✅ Session saved to {args.output}")
+
+
+if __name__ == "__main__":
+    main()
+

--- a/models/dryland_models.py
+++ b/models/dryland_models.py
@@ -1,0 +1,35 @@
+from __future__ import annotations
+
+from datetime import date
+from typing import List, Optional
+
+from pydantic import BaseModel
+
+
+class DrylandPlanOutput(BaseModel):
+    start_date: date
+    weeks: int
+    weekly_focus: dict[str, str]
+    template_session: dict[str, str]
+    goals: List[str]
+
+
+class DrylandSessionOutput(BaseModel):
+    date: date
+    focus_area: str
+    warmup: List[str]
+    main_set: List[str]
+    cooldown: List[str]
+    equipment_needed: List[str]
+    video_refs: List[str]
+
+
+class DrylandContext(BaseModel):
+    age_group: Optional[str] = None
+    season_phase: Optional[str] = None  # pre/in/post
+    team_level: Optional[str] = None
+    equipment: List[str] = []
+    space: Optional[str] = None
+    plan: Optional[DrylandPlanOutput] = None
+    notes: Optional[str] = None
+

--- a/prompts/off_ice/dryland_plan_prompt.yaml
+++ b/prompts/off_ice/dryland_plan_prompt.yaml
@@ -1,0 +1,11 @@
+prompt: |
+  You're a dryland planning agent for youth hockey. Gather:
+  - Age group, season phase, team level
+  - Equipment/space available
+  - Weekly frequency
+
+  Generate a multi-week plan with:
+  - Weekly focus areas
+  - Template session structure
+  - Player development goals
+  Use tools to gather relevant drills and videos.

--- a/prompts/off_ice/dryland_session_prompt.yaml
+++ b/prompts/off_ice/dryland_session_prompt.yaml
@@ -1,0 +1,5 @@
+prompt: |
+  You're a dryland session generator. Use plan from context to:
+  - Identify week and focus area
+  - Generate full workout session (warmup, main, cooldown)
+  Use tools to retrieve drills/videos. Ask coach for feedback.


### PR DESCRIPTION
## Summary
- add dryland planning/session Pydantic models
- create prompts for dryland planner and session agents
- implement dryland planner and session agents with context-update tool
- add CLI loop agent to orchestrate planning then session generation

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68780abd064883268936457b26eb5fd6