### PR TITLE
Fix: CSP header for Notion embedding

### DIFF
--- a/thunder_quiz/app/next.config.js
+++ b/thunder_quiz/app/next.config.js
@@ -10,7 +10,7 @@ const nextConfig = {
           // Instead, use CSP frame-ancestors
           {
             key: 'Content-Security-Policy',
-            value: "frame-ancestors 'self' https://www.notion.so https://*.notion.site;"
+            value: "frame-ancestors https://www.notion.so https://*.notion.site;"
           },
           {
             key: 'X-Content-Type-Options',


### PR DESCRIPTION
Removes 'self' from Content-Security-Policy frame-ancestors to allow proper Notion embedding.

## Issue
- Notion shows 'not embeddable' error
- CSP included 'self' which prevents Notion from embedding the iframe

## Solution  
- Removed 'self' from frame-ancestors
- Now only allows Notion domains as specified in their requirements

🤖 Generated with [Claude Code](https://claude.ai/code)