### PR TITLE
Fix: Restore 'self' to CSP for Notion embedding

### DIFF
--- a/thunder_quiz/app/next.config.js
+++ b/thunder_quiz/app/next.config.js
@@ -10,7 +10,7 @@ const nextConfig = {
           // Instead, use CSP frame-ancestors
           {
             key: 'Content-Security-Policy',
-            value: "frame-ancestors https://www.notion.so https://*.notion.site;"
+            value: "frame-ancestors 'self' https://www.notion.so https://*.notion.site;"
           },
           {
             key: 'X-Content-Type-Options',


### PR DESCRIPTION
Reverts previous CSP change. Testing shows Notion actually REQUIRES 'self' in frame-ancestors.

## Issue
- App not embeddable in Notion after removing 'self' from CSP
- Working deployment (2cmgg0qvw) has 'self' and embeds properly

## Solution
- Restored: frame-ancestors 'self' https://www.notion.so https://*.notion.site
- This matches the working deployment configuration

🤖 Generated with [Claude Code](https://claude.ai/code)