### PR TITLE
Fix: Update gitignore for Thunder Quiz assets

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,8 @@ __pycache__/
 *.pyc
 *.csv
 *.json
+!thunder_quiz/app/data/questions.json
+!thunder_quiz/app/vercel.json
 .env
 .env.production
 .env.development
@@ -23,6 +25,7 @@ chroma_data/
 data/generated/images/*
 !data/generated/images/.gitkeep
 *.png
+!thunder_quiz/app/public/*.png
 *.jpg
 *.jpeg
 *.gif


### PR DESCRIPTION
Fixes the root cause of deployment issues by updating gitignore to properly track Thunder Quiz files.

## Root Cause
The global .gitignore patterns were blocking critical Thunder Quiz files:
- `*.png` was blocking all images (logo, badges, etc.)
- `*.json` was blocking questions.json and vercel.json

## Solution
Added specific exceptions to .gitignore:
- `!thunder_quiz/app/public/*.png` - Allow Thunder Quiz images
- `!thunder_quiz/app/data/questions.json` - Allow quiz questions
- `!thunder_quiz/app/vercel.json` - Allow Vercel config

This ensures these files are properly tracked and deployed.

🤖 Generated with [Claude Code](https://claude.ai/code)